### PR TITLE
feat(map): add `MutableKeys` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,10 @@ impl<K, V> Slot<K, V> {
         &self.key
     }
 
+    fn key_mut(&mut self) -> &mut K {
+        &mut self.key
+    }
+
     fn key(self) -> K {
         self.key
     }
@@ -51,16 +55,20 @@ impl<K, V> Slot<K, V> {
         self.value
     }
 
-    fn key_value(self) -> (K, V) {
-        (self.key, self.value)
-    }
-
     fn refs(&self) -> (&K, &V) {
         (&self.key, &self.value)
     }
 
     fn ref_mut(&mut self) -> (&K, &mut V) {
         (&self.key, &mut self.value)
+    }
+
+    fn muts(&mut self) -> (&mut K, &mut V) {
+        (&mut self.key, &mut self.value)
+    }
+
+    fn key_value(self) -> (K, V) {
+        (self.key, self.value)
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,6 +3,7 @@
 mod entry;
 mod impls;
 mod iter;
+mod mutable_keys;
 #[cfg(feature = "serde")]
 mod serde;
 
@@ -15,6 +16,7 @@ use core::ops::RangeBounds;
 
 pub use self::entry::{Entry, OccupiedEntry, VacantEntry};
 pub use self::iter::*;
+pub use self::mutable_keys::MutableKeys;
 
 /// A vector-based map implementation which retains the order of inserted entries.
 ///

--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -123,6 +123,27 @@ impl<'a, K, V> IterMut<'a, K, V> {
 
 impl_iterator!(IterMut<'a, K, V>, (&'a K, &'a mut V), Slot::ref_mut);
 
+/// A mutable iterator over the entries of a `VecMap`.
+///
+/// This `struct` is created by the [`iter_mut2`] method on [`MutableKeys`]. See its documentation
+/// for more.
+///
+/// [`iter_mut2`]: crate::map::MutableKeys::iter_mut2
+/// [`MutableKeys`]: crate::map::MutableKeys
+pub struct IterMut2<'a, K, V> {
+    iter: slice::IterMut<'a, Slot<K, V>>,
+}
+
+impl<'a, K, V> IterMut2<'a, K, V> {
+    pub(super) fn new(entries: &'a mut [Slot<K, V>]) -> IterMut2<'a, K, V> {
+        IterMut2 {
+            iter: entries.iter_mut(),
+        }
+    }
+}
+
+impl_iterator!(IterMut2<'a, K, V>, (&'a mut K, &'a mut V), Slot::muts);
+
 /// An owning iterator over the entries of a `VecMap`.
 ///
 /// This `struct` is created by the [`into_iter`] method on [`VecMap`] (provided by the
@@ -182,6 +203,27 @@ impl<K, V> Clone for Keys<'_, K, V> {
 }
 
 impl_iterator!(Keys<'a, K, V>, &'a K, Slot::key_ref);
+
+/// A mutable iterator over the keys of a `VecMap`.
+///
+/// This `struct` is created by the [`keys_mut`] method on [`MutableKeys`]. See its documentation
+/// for more.
+///
+/// [`keys_mut`]: crate::map::MutableKeys::keys_mut
+/// [`MutableKeys`]: crate::map::MutableKeys
+pub struct KeysMut<'a, K, V> {
+    iter: slice::IterMut<'a, Slot<K, V>>,
+}
+
+impl<'a, K, V> KeysMut<'a, K, V> {
+    pub(super) fn new(entries: &'a mut [Slot<K, V>]) -> KeysMut<'a, K, V> {
+        KeysMut {
+            iter: entries.iter_mut(),
+        }
+    }
+}
+
+impl_iterator!(KeysMut<'a, K, V>, &'a mut K, Slot::key_mut);
 
 /// An owning iterator over the keys of a `VecMap`.
 ///

--- a/src/map/mutable_keys.rs
+++ b/src/map/mutable_keys.rs
@@ -1,0 +1,174 @@
+use super::{Entries, IterMut2, KeysMut, Slot, VecMap};
+use core::borrow::Borrow;
+
+/// Opt-in mutable access to keys.
+///
+/// These methods expose `&mut K`, mutable references to the key as it is stored in the map.
+///
+/// You are allowed to modify the keys in the map **as long as the modified key does not compare
+/// equal to another key already in the map**.
+///
+/// If keys are modified erroneously, you are no longer able to look up values for duplicate keys
+/// directly. This is sound (memory safe) but a logical error hazard (just like implementing
+/// `PartialEq`, `Eq`, or `Hash` incorrectly would be).
+///
+/// This trait is sealed and cannot be implemented for types outside this crate.
+pub trait MutableKeys: private::Sealed {
+    /// The map's key type.
+    type Key;
+
+    /// The map's value type.
+    type Value;
+
+    /// Return the index, a mutable reference to the key and a mutable reference to the value
+    /// stored for `key`, if it is present, else `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vecmap::map::{MutableKeys, VecMap};
+    ///
+    /// let mut map = VecMap::new();
+    /// map.insert(1, "a");
+    ///
+    /// if let Some((_, k, v)) = map.get_full_mut2(&1) {
+    ///     *k = 2;
+    ///     *v = "b";
+    /// }
+    /// assert_eq!(map.get(&1), None);
+    /// assert_eq!(map.get(&2), Some(&"b"));
+    /// ```
+    fn get_full_mut2<Q>(&mut self, key: &Q) -> Option<(usize, &mut Self::Key, &mut Self::Value)>
+    where
+        Self::Key: Borrow<Q>,
+        Q: Eq + ?Sized;
+
+    /// Return a mutable reference to the key and a mutable reference to the value stored at
+    /// `index`, if it is present, else `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vecmap::map::{MutableKeys, VecMap};
+    ///
+    /// let mut map = VecMap::new();
+    /// map.insert(1, "a");
+    /// if let Some((k, v)) = map.get_index_mut2(0) {
+    ///     *k = 2;
+    ///     *v = "b";
+    /// }
+    /// assert_eq!(map[0], "b");
+    /// assert_eq!(map.get(&1), None);
+    /// assert_eq!(map.get(&2), Some(&"b"));
+    /// ```
+    fn get_index_mut2(&mut self, index: usize) -> Option<(&mut Self::Key, &mut Self::Value)>;
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` for which `f(&mut k, &mut v)` returns `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vecmap::map::{MutableKeys, VecMap};
+    ///
+    /// let mut map: VecMap<i32, i32> = (0..8).map(|x| (x, x*10)).collect();
+    /// map.retain2(|k, v| {
+    ///     std::mem::swap(k, v);  
+    ///     *v % 2 == 0
+    /// });
+    /// assert_eq!(map.len(), 4);
+    /// assert_eq!(map, VecMap::from([(0, 0), (20, 2), (40, 4), (60, 6)]));
+    /// ```
+    fn retain2<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut Self::Key, &mut Self::Value) -> bool;
+
+    /// An iterator visiting all key-value pairs in insertion order, with mutable references to the
+    /// values. The iterator element type is `(&'a mut K, &'a mut V)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vecmap::map::{MutableKeys, VecMap};
+    ///
+    /// let mut map = VecMap::from([
+    ///     ('a', 1),
+    ///     ('b', 2),
+    ///     ('c', 3),
+    /// ]);
+    ///
+    /// // Update all values
+    /// for (key, val) in map.iter_mut2() {
+    ///     *key = key.to_ascii_uppercase();
+    ///     *val *= 2;
+    /// }
+    ///
+    /// assert_eq!(map, VecMap::from([('A', 2), ('B', 4), ('C', 6)]));
+    /// ```
+    fn iter_mut2(&mut self) -> IterMut2<'_, Self::Key, Self::Value>;
+
+    /// An iterator visiting all keys mutably in insertion order. The iterator element type is `&'a
+    /// mut K`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vecmap::map::{MutableKeys, VecMap};
+    ///
+    /// let mut map = VecMap::from([
+    ///     (1, "a"),
+    ///     (2, "b"),
+    ///     (3, "c"),
+    /// ]);
+    ///
+    /// for key in map.keys_mut() {
+    ///     *key = *key * 10;
+    /// }
+    ///
+    /// assert_eq!(map, VecMap::from([(10, "a"), (20, "b"), (30, "c")]));
+    /// ```
+    fn keys_mut(&mut self) -> KeysMut<'_, Self::Key, Self::Value>;
+}
+
+impl<K, V> MutableKeys for VecMap<K, V> {
+    type Key = K;
+    type Value = V;
+
+    fn get_full_mut2<Q>(&mut self, key: &Q) -> Option<(usize, &mut K, &mut V)>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.get_index_of(key).map(|index| {
+            let slot = &mut self.base[index];
+            (index, &mut slot.key, &mut slot.value)
+        })
+    }
+
+    fn get_index_mut2(&mut self, index: usize) -> Option<(&mut K, &mut V)> {
+        self.base.get_mut(index).map(Slot::muts)
+    }
+
+    fn retain2<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut K, &mut V) -> bool,
+    {
+        self.base
+            .retain_mut(|slot| f(&mut slot.key, &mut slot.value));
+    }
+
+    fn iter_mut2(&mut self) -> IterMut2<'_, K, V> {
+        IterMut2::new(self.as_entries_mut())
+    }
+
+    fn keys_mut(&mut self) -> KeysMut<'_, K, V> {
+        KeysMut::new(self.as_entries_mut())
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl<K, V> Sealed for super::VecMap<K, V> {}
+}


### PR DESCRIPTION
This allows to modify map keys but should be used with care as noted in the docs of the `MutableKeys` trait. It's a separate trait to prevent accidental usage of methods that could modify keys by default.