### PR TITLE
feat(map): avoid allocations in conversion from vector or slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,3 +83,32 @@ trait Entries {
 
     fn into_entries(self) -> Vec<Self::Entry>;
 }
+
+/// Deduplicate elements in an unsorted vector.
+fn dedup<T>(vec: &mut Vec<T>, eq_fn: impl Fn(&T, &T) -> bool) {
+    let mut out = 1;
+    let len = vec.len();
+    for i in 1..len {
+        if (0..i).all(|j| !eq_fn(&vec[i], &vec[j])) {
+            vec.swap(out, i);
+            out += 1;
+        }
+    }
+    vec.truncate(out);
+}
+
+#[test]
+fn test_dedup() {
+    fn test(want: &[u32], arr: &[u32]) {
+        let mut vec = arr.to_vec();
+        dedup(&mut vec, |i, j| i == j);
+        assert_eq!(want, vec.as_slice());
+    }
+
+    test(&[], &[]);
+    test(&[1], &[1]);
+    test(&[1], &[1, 1]);
+    test(&[1], &[1, 1, 1]);
+    test(&[3, 1, 2], &[3, 1, 2]);
+    test(&[3, 1, 2], &[3, 1, 2, 1, 2, 3]);
+}

--- a/src/map/impls.rs
+++ b/src/map/impls.rs
@@ -122,7 +122,7 @@ where
     /// the vector and use [`VecMap::from_vec_unchecked`] instead.
     fn from(mut vec: Vec<(K, V)>) -> Self {
         crate::dedup(&mut vec, |rhs, lhs| rhs.0 == lhs.0);
-        // SUPER: We’ve just deduplicated the elements.
+        // SAFETY: We’ve just deduplicated the elements.
         unsafe { Self::from_vec_unchecked(vec) }
     }
 }


### PR DESCRIPTION
Most notably, introduce VecMap::from_vec_unchecked method which takes
ownership of a vector and constructs VecMap out of it without checking
for duplicate keys.  If client knows there are no duplicate keys in
the argument, they can use this to avoid quadratic checking done
otherwise.

With that, change `From<Vec>` implementation so that it doesn’t
allocate a new vector.  Instead, it deduplicates elements in provided
vector and then uses that storage for the constructed VecMap.

Lastly, add FromIterator and Extend implementations for `&(K, V)`
items so that conversion from slice doesn’t have to implement
temporary vector.
