### PR TITLE
fix(map): prevent segmentation fault in `VecMap::as_slice`

### DIFF
--- a/src/map/mutable_keys.rs
+++ b/src/map/mutable_keys.rs
@@ -142,7 +142,7 @@ impl<K, V> MutableKeys for VecMap<K, V> {
     {
         self.get_index_of(key).map(|index| {
             let slot = &mut self.base[index];
-            (index, &mut slot.key, &mut slot.value)
+            (index, &mut slot.entry.0, &mut slot.entry.1)
         })
     }
 
@@ -155,7 +155,7 @@ impl<K, V> MutableKeys for VecMap<K, V> {
         F: FnMut(&mut K, &mut V) -> bool,
     {
         self.base
-            .retain_mut(|slot| f(&mut slot.key, &mut slot.value));
+            .retain_mut(|slot| f(&mut slot.entry.0, &mut slot.entry.1));
     }
 
     fn iter_mut2(&mut self) -> IterMut2<'_, K, V> {


### PR DESCRIPTION
Fixes #18.

The unsafe conversion from `&[Slot<K, V>]` to `&[(K, V)]` was, unlike stated in the safety comment, not sound since `Slot<K, V>`'s field may get reordered by the compiler, which produces a different memory layout than `(K, V)`.

This change makes `Slot<K, V>` a transparent wrapper around `(K, V)` which avoid running into this safetly issue in `VecMap::as_slice` and adds a regression test.