### PR TITLE
chore: improve internal `Slot<K, V>` API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,72 +24,69 @@ pub use self::set::VecSet;
 use alloc::vec::Vec;
 
 // The type used to store entries in a `VecMap`.
+//
+// It is just a transparent wrapper around `(K, V)` with accessor methods for use in `map`
+// functions.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Slot<K, V> {
-    entry: (K, V),
+    data: (K, V),
 }
 
-// Accessor methods which can be used in `map` functions.
 impl<K, V> Slot<K, V> {
     #[inline]
     fn new(key: K, value: V) -> Self {
-        Slot {
-            entry: (key, value),
-        }
+        Slot { data: (key, value) }
     }
-}
 
-// Accessor methods which can be used in `map` functions.
-impl<K, V> Slot<K, V> {
     #[inline]
-    fn key_ref(&self) -> &K {
-        &self.entry.0
+    fn key(&self) -> &K {
+        &self.data.0
     }
 
     #[inline]
     fn key_mut(&mut self) -> &mut K {
-        &mut self.entry.0
+        &mut self.data.0
     }
 
     #[inline]
-    fn key(self) -> K {
-        self.entry.0
+    fn into_key(self) -> K {
+        self.data.0
     }
 
     #[inline]
-    fn value_ref(&self) -> &V {
-        &self.entry.1
+    fn value(&self) -> &V {
+        &self.data.1
     }
 
     #[inline]
     fn value_mut(&mut self) -> &mut V {
-        &mut self.entry.1
+        &mut self.data.1
     }
 
     #[inline]
-    fn value(self) -> V {
-        self.entry.1
+    fn into_value(self) -> V {
+        self.data.1
     }
 
     #[inline]
     fn refs(&self) -> (&K, &V) {
-        (&self.entry.0, &self.entry.1)
+        (&self.data.0, &self.data.1)
     }
 
     #[inline]
     fn ref_mut(&mut self) -> (&K, &mut V) {
-        (&self.entry.0, &mut self.entry.1)
+        (&self.data.0, &mut self.data.1)
     }
 
     #[inline]
     fn muts(&mut self) -> (&mut K, &mut V) {
-        (&mut self.entry.0, &mut self.entry.1)
+        (&mut self.data.0, &mut self.data.1)
     }
 
     #[inline]
-    fn key_value(self) -> (K, V) {
-        (self.entry.0, self.entry.1)
+    fn into_key_value(self) -> (K, V) {
+        self.data
     }
 }
 

--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -175,7 +175,7 @@ where
     }
 }
 
-impl_iterator!(IntoIter<K, V>, (K, V), Slot::key_value);
+impl_iterator!(IntoIter<K, V>, (K, V), Slot::into_key_value);
 
 /// An iterator over the keys of a `VecMap`.
 ///
@@ -202,7 +202,7 @@ impl<K, V> Clone for Keys<'_, K, V> {
     }
 }
 
-impl_iterator!(Keys<'a, K, V>, &'a K, Slot::key_ref);
+impl_iterator!(Keys<'a, K, V>, &'a K, Slot::key);
 
 /// A mutable iterator over the keys of a `VecMap`.
 ///
@@ -255,7 +255,7 @@ where
     }
 }
 
-impl_iterator!(IntoKeys<K, V>, K, Slot::key);
+impl_iterator!(IntoKeys<K, V>, K, Slot::into_key);
 
 /// An iterator over the values of a `VecMap`.
 ///
@@ -283,7 +283,7 @@ impl<K, V> Clone for Values<'_, K, V> {
     }
 }
 
-impl_iterator!(Values<'a, K, V>, &'a V, Slot::value_ref);
+impl_iterator!(Values<'a, K, V>, &'a V, Slot::value);
 
 /// A mutable iterator over the values of a `VecMap`.
 ///
@@ -335,7 +335,7 @@ where
     }
 }
 
-impl_iterator!(IntoValues<K, V>, V, Slot::value);
+impl_iterator!(IntoValues<K, V>, V, Slot::into_value);
 
 /// A draining iterator for `VecMap`.
 ///
@@ -362,4 +362,4 @@ impl<'a, K, V> Drain<'a, K, V> {
     }
 }
 
-impl_iterator!(Drain<'a, K, V>, (K, V), Slot::key_value);
+impl_iterator!(Drain<'a, K, V>, (K, V), Slot::into_key_value);

--- a/src/map/mutable_keys.rs
+++ b/src/map/mutable_keys.rs
@@ -141,8 +141,8 @@ impl<K, V> MutableKeys for VecMap<K, V> {
         Q: Eq + ?Sized,
     {
         self.get_index_of(key).map(|index| {
-            let slot = &mut self.base[index];
-            (index, &mut slot.entry.0, &mut slot.entry.1)
+            let (key, value) = self.base[index].muts();
+            (index, key, value)
         })
     }
 
@@ -154,8 +154,10 @@ impl<K, V> MutableKeys for VecMap<K, V> {
     where
         F: FnMut(&mut K, &mut V) -> bool,
     {
-        self.base
-            .retain_mut(|slot| f(&mut slot.entry.0, &mut slot.entry.1));
+        self.base.retain_mut(|slot| {
+            let (key, value) = slot.muts();
+            f(key, value)
+        });
     }
 
     fn iter_mut2(&mut self) -> IterMut2<'_, K, V> {

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -39,7 +39,7 @@ macro_rules! impl_iterator {
             T: fmt::Debug,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let iter = self.iter.as_slice().iter().map(Slot::key_ref);
+                let iter = self.iter.as_slice().iter().map(Slot::key);
                 f.debug_list().entries(iter).finish()
             }
         }
@@ -91,7 +91,7 @@ impl<T> Clone for Iter<'_, T> {
     }
 }
 
-impl_iterator!(Iter<'a, T>, &'a T, Slot::key_ref);
+impl_iterator!(Iter<'a, T>, &'a T, Slot::key);
 
 /// An owning iterator over the elements of a `VecSet`.
 ///
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl_iterator!(IntoIter<T>, T, Slot::key);
+impl_iterator!(IntoIter<T>, T, Slot::into_key);
 
 /// A lazy iterator producing elements in the difference of `VecSet`s.
 ///


### PR DESCRIPTION
Followup to #19.

- Rename `Slot<K, V>`'s sole field from `entry` to `data` which makes more sense in this context I think.
- Rename methods to better align with rust best practices, e.g. `key_ref` -> `key`, `value` -> `into_value`, etc.
- Replace direct accesses to `data.0` and `data.1` with accessor method calls to make the code cleaner.