### PR TITLE
fix(map)!: update API of `VecMap::retain` to be consistent with std

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -205,7 +205,7 @@ impl<K, V> VecMap<K, V> {
     /// ```
     pub fn retain<F>(&mut self, mut f: F)
     where
-        F: FnMut(&K, &V) -> bool,
+        F: FnMut(&K, &mut V) -> bool,
     {
         self.base.retain_mut(|slot| {
             let (key, value) = slot.ref_mut();


### PR DESCRIPTION
#24 