### PR TITLE
Add KeyedVecSet as internal abstraction layer

### DIFF
--- a/src/keyed.rs
+++ b/src/keyed.rs
@@ -12,7 +12,7 @@ use alloc::vec::{self, Vec};
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::mem;
-use core::ops::{Index, IndexMut, RangeBounds};
+use core::ops::RangeBounds;
 use core::slice;
 
 /// Key accessor for elements which have their own keys, used for `KeyedVecSet`.
@@ -64,7 +64,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// use vecmap::keyed::KeyedVecSet;
     ///
     /// let set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
-    /// ```ignore
+    /// ```
     pub const fn new() -> Self {
         KeyedVecSet {
             base: Vec::new(),
@@ -83,7 +83,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::with_capacity(10);
     /// assert_eq!(set.len(), 0);
     /// assert!(set.capacity() >= 10);
-    /// ```ignore
+    /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         KeyedVecSet {
             base: Vec::with_capacity(capacity),
@@ -100,7 +100,7 @@ impl<K, V> KeyedVecSet<K, V> {
     ///
     /// let set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::with_capacity(10);
     /// assert!(set.capacity() >= 10);
-    /// ```ignore
+    /// ```
     pub fn capacity(&self) -> usize {
         self.base.capacity()
     }
@@ -123,7 +123,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// assert_eq!(a.len(), 0);
     /// a.insert(Entry(1, "a"));
     /// assert_eq!(a.len(), 1);
-    /// ```ignore
+    /// ```
     pub fn len(&self) -> usize {
         self.base.len()
     }
@@ -146,7 +146,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// assert!(a.is_empty());
     /// a.insert(Entry(1, "a"));
     /// assert!(!a.is_empty());
-    /// ```ignore
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.base.is_empty()
     }
@@ -169,7 +169,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// a.insert(Entry(1, "a"));
     /// a.clear();
     /// assert!(a.is_empty());
-    /// ```ignore
+    /// ```
     pub fn clear(&mut self) {
         self.base.clear();
     }
@@ -197,7 +197,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry("d", 4));
     /// map.truncate(2);
     /// assert_eq!(map.len(), 2);
-    /// ```ignore
+    /// ```
     pub fn truncate(&mut self, len: usize) {
         self.base.truncate(len);
     }
@@ -224,7 +224,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// assert_eq!(map.get_index(0), Some(&Entry(3, "c")));
     /// assert_eq!(map.get_index(1), Some(&Entry(2, "b")));
     /// assert_eq!(map.get_index(2), Some(&Entry(1, "a")));
-    /// ```ignore
+    /// ```
     pub fn reverse(&mut self) {
         self.base.reverse();
     }
@@ -246,7 +246,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
     /// set.reserve(10);
     /// assert!(set.capacity() >= 10);
-    /// ```ignore
+    /// ```
     pub fn reserve(&mut self, additional: usize) {
         self.base.reserve(additional);
     }
@@ -270,7 +270,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
     /// set.reserve_exact(10);
     /// assert!(set.capacity() >= 10);
-    /// ```ignore
+    /// ```
     pub fn reserve_exact(&mut self, additional: usize) {
         self.base.reserve_exact(additional);
     }
@@ -293,7 +293,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
     /// set.try_reserve(10).expect("should reserve");
     /// assert!(set.capacity() >= 10);
-    /// ```ignore
+    /// ```
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.base.try_reserve(additional)
     }
@@ -320,7 +320,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
     /// set.try_reserve_exact(10).expect("should reserve");
     /// assert!(set.capacity() >= 10);
-    /// ```ignore
+    /// ```
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.base.try_reserve_exact(additional)
     }
@@ -346,7 +346,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// map.shrink_to_fit();
     /// assert!(map.capacity() >= 2);
-    /// ```ignore
+    /// ```
     pub fn shrink_to_fit(&mut self) {
         self.base.shrink_to_fit();
     }
@@ -374,7 +374,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// map.shrink_to(4);
     /// assert!(map.capacity() >= 4);
-    /// ```ignore
+    /// ```
     pub fn shrink_to(&mut self, min_capacity: usize) {
         self.base.shrink_to(min_capacity);
     }
@@ -408,7 +408,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let map2 = map.split_off(1);
     /// assert_eq!(map.len(), 1);
     /// assert_eq!(map2.len(), 2);
-    /// ```ignore
+    /// ```
     pub fn split_off(&mut self, at: usize) -> KeyedVecSet<K, V> {
         KeyedVecSet {
             base: self.base.split_off(at),
@@ -446,7 +446,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let drained: Vec<_> = map.drain(1..).collect();
     /// assert_eq!(drained, vec![Entry(2, "b"), Entry(3, "c")]);
     /// assert_eq!(map.len(), 1);
-    /// ```ignore
+    /// ```
     pub fn drain<R>(&mut self, range: R) -> vec::Drain<'_, V>
     where
         R: RangeBounds<usize>,
@@ -474,7 +474,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(3, "c"));
     /// map.retain(|entry| entry.0 % 2 == 1);
     /// assert_eq!(map.len(), 2);
-    /// ```ignore
+    /// ```
     pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&V) -> bool,
@@ -505,7 +505,7 @@ impl<K, V> KeyedVecSet<K, V> {
     ///     entry.0 % 2 == 1
     /// });
     /// assert_eq!(map.len(), 2);
-    /// ```ignore
+    /// ```
     pub fn retain_mut<F>(&mut self, f: F)
     where
         F: FnMut(&mut V) -> bool,
@@ -533,7 +533,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// map.sort_by(|a, b| a.0.cmp(&b.0));
     /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
-    /// ```ignore
+    /// ```
     pub fn sort_by<F>(&mut self, compare: F)
     where
         F: FnMut(&V, &V) -> Ordering,
@@ -561,7 +561,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// map.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
-    /// ```ignore
+    /// ```
     pub fn sort_unstable_by<F>(&mut self, compare: F)
     where
         F: FnMut(&V, &V) -> Ordering,
@@ -595,7 +595,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// map.sort_by_cached_key(|entry| entry.0);
     /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
-    /// ```ignore
+    /// ```
     pub fn sort_by_cached_key<T, F>(&mut self, sort_key: F)
     where
         T: Ord,
@@ -633,7 +633,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.swap_indices(0, 1);
     /// assert_eq!(map.get_index(0), Some(&Entry(2, "b")));
     /// assert_eq!(map.get_index(1), Some(&Entry(1, "a")));
-    /// ```ignore
+    /// ```
     pub fn swap_indices(&mut self, a: usize, b: usize) {
         self.base.swap(a, b);
     }
@@ -657,7 +657,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// let slice = map.as_slice();
     /// assert_eq!(slice.len(), 2);
-    /// ```ignore
+    /// ```
     pub fn as_slice(&self) -> &[V] {
         self.base.as_slice()
     }
@@ -682,7 +682,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// let slice = map.as_mut_slice();
     /// slice[0] = Entry(3, "c");
     /// assert_eq!(map.get_index(0), Some(&Entry(3, "c")));
-    /// ```ignore
+    /// ```
     pub fn as_mut_slice(&mut self) -> &mut [V] {
         self.base.as_mut_slice()
     }
@@ -706,7 +706,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// let vec = map.to_vec();
     /// assert_eq!(vec, vec![Entry(1, "a"), Entry(2, "b")]);
-    /// ```ignore
+    /// ```
     pub fn to_vec(&self) -> Vec<V>
     where
         V: Clone,
@@ -733,7 +733,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(2, "b"));
     /// let vec = map.into_vec();
     /// assert_eq!(vec, vec![Entry(1, "a"), Entry(2, "b")]);
-    /// ```ignore
+    /// ```
     pub fn into_vec(self) -> Vec<V> {
         self.base
     }
@@ -782,7 +782,7 @@ where
     /// assert_eq!(map.get_index_of("a"), Some(0));
     /// assert_eq!(map.get_index_of("b"), Some(1));
     /// assert_eq!(map.get_index_of("c"), None);
-    /// ```ignore
+    /// ```
     pub fn get_index_of<Q>(&self, key: &Q) -> Option<usize>
     where
         K: Borrow<Q>,
@@ -812,7 +812,7 @@ where
     /// map.insert(Entry(1, "a"));
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
-    /// ```ignore
+    /// ```
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -839,7 +839,7 @@ where
     /// map.insert(Entry(1, "a"));
     /// assert_eq!(map.get(&1), Some(&Entry(1, "a")));
     /// assert_eq!(map.get(&2), None);
-    /// ```ignore
+    /// ```
     pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -866,7 +866,7 @@ where
     /// map.insert(Entry(1, "a"));
     /// assert_eq!(map.get_full(&1), Some((0, &Entry(1, "a"))));
     /// assert_eq!(map.get_full(&2), None);
-    /// ```ignore
+    /// ```
     pub fn get_full<Q>(&self, key: &Q) -> Option<(usize, &V)>
     where
         K: Borrow<Q>,
@@ -896,7 +896,7 @@ where
     ///     *entry = Entry(1, "b");
     /// }
     /// assert_eq!(map.get(&1), Some(&Entry(1, "b")));
-    /// ```ignore
+    /// ```
     pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -923,7 +923,7 @@ where
     /// map.insert(Entry(1, "a"));
     /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
     /// assert_eq!(map.get_index(1), None);
-    /// ```ignore
+    /// ```
     pub fn get_index(&self, index: usize) -> Option<&V> {
         self.base.get(index)
     }
@@ -948,7 +948,7 @@ where
     ///     *entry = Entry(2, "b");
     /// }
     /// assert_eq!(map.get_index(0), Some(&Entry(2, "b")));
-    /// ```ignore
+    /// ```
     pub fn get_index_mut(&mut self, index: usize) -> Option<&mut V> {
         self.base.get_mut(index)
     }
@@ -971,7 +971,7 @@ where
     /// map.insert(Entry(1, "a"));
     /// map.insert(Entry(2, "b"));
     /// assert_eq!(map.first(), Some(&Entry(1, "a")));
-    /// ```ignore
+    /// ```
     pub fn first(&self) -> Option<&V> {
         self.base.first()
     }
@@ -997,7 +997,7 @@ where
     ///     *entry = Entry(3, "c");
     /// }
     /// assert_eq!(map.first(), Some(&Entry(3, "c")));
-    /// ```ignore
+    /// ```
     pub fn first_mut(&mut self) -> Option<&mut V> {
         self.base.first_mut()
     }
@@ -1020,7 +1020,7 @@ where
     /// map.insert(Entry(1, "a"));
     /// map.insert(Entry(2, "b"));
     /// assert_eq!(map.last(), Some(&Entry(2, "b")));
-    /// ```ignore
+    /// ```
     pub fn last(&self) -> Option<&V> {
         self.base.last()
     }
@@ -1046,7 +1046,7 @@ where
     ///     *entry = Entry(3, "c");
     /// }
     /// assert_eq!(map.last(), Some(&Entry(3, "c")));
-    /// ```ignore
+    /// ```
     pub fn last_mut(&mut self) -> Option<&mut V> {
         self.base.last_mut()
     }
@@ -1075,7 +1075,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// assert_eq!(map.pop(), Some(Entry("a", 1)));
     /// assert!(map.is_empty());
     /// assert_eq!(map.pop(), None);
-    /// ```ignore
+    /// ```
     pub fn pop(&mut self) -> Option<V> {
         self.base.pop()
     }
@@ -1104,7 +1104,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// map.insert(Entry(3, "c"));
     /// assert_eq!(map.remove_index(1), Entry(2, "b"));
     /// assert_eq!(map.len(), 2);
-    /// ```ignore
+    /// ```
     pub fn remove_index(&mut self, index: usize) -> V {
         self.base.remove(index)
     }
@@ -1136,7 +1136,7 @@ impl<K, V> KeyedVecSet<K, V> {
     /// assert_eq!(map.swap_remove_index(1), Entry(2, "b"));
     /// assert_eq!(map.len(), 2);
     /// // Note: Entry(3, "c") moved to index 1
-    /// ```ignore
+    /// ```
     pub fn swap_remove_index(&mut self, index: usize) -> V {
         self.base.swap_remove(index)
     }
@@ -1169,7 +1169,7 @@ where
     /// map.insert(Entry(3, "c"));
     /// assert_eq!(map.remove(&2), Some(Entry(2, "b")));
     /// assert_eq!(map.remove(&2), None);
-    /// ```ignore
+    /// ```
     pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -1203,7 +1203,7 @@ where
     /// assert_eq!(map.swap_remove(&2), Some(Entry(2, "b")));
     /// assert_eq!(map.swap_remove(&2), None);
     /// // Note: element order changed - Entry(4, "d") moved to index 1
-    /// ```ignore
+    /// ```
     pub fn swap_remove<Q>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -1255,7 +1255,7 @@ where
     ///
     /// map.insert(Entry(37, "b"));
     /// assert_eq!(map.insert(Entry(37, "c")), Some(Entry(37, "b")));
-    /// ```ignore
+    /// ```
     pub fn insert(&mut self, value: V) -> Option<V> {
         self.insert_full(value).1
     }
@@ -1285,7 +1285,7 @@ where
     /// assert_eq!(map.insert_full(Entry("a", 1)), (0, None));
     /// assert_eq!(map.insert_full(Entry("b", 2)), (1, None));
     /// assert_eq!(map.insert_full(Entry("b", 3)), (1, Some(Entry("b", 2))));
-    /// ```ignore
+    /// ```
     pub fn insert_full(&mut self, value: V) -> (usize, Option<V>) {
         let key = value.key();
         if let Some(index) = self.get_index_of(key) {
@@ -1327,7 +1327,7 @@ where
     /// assert_eq!(map.insert_at(0, Entry("a", 1)), None);
     /// assert_eq!(map.insert_at(1, Entry("b", 2)), None);
     /// assert_eq!(map.insert_at(0, Entry("b", 3)), Some((1, Entry("b", 2))));
-    /// ```ignore
+    /// ```
     pub fn insert_at(&mut self, index: usize, value: V) -> Option<(usize, V)> {
         let key = value.key();
         if let Some(old_index) = self.get_index_of(key) {
@@ -1379,7 +1379,7 @@ where
     /// assert_eq!(a.len(), 5);
     /// assert_eq!(b.len(), 0);
     /// assert_eq!(b.capacity(), old_capacity);
-    /// ```ignore
+    /// ```
     pub fn append(&mut self, other: &mut KeyedVecSet<K, V>) {
         self.reserve(other.len());
         for value in other.drain(..) {
@@ -1411,23 +1411,8 @@ impl<K, V> KeyedVecSet<K, V> {
     /// assert_eq!(iter.next(), Some(&Entry(1, "a")));
     /// assert_eq!(iter.next(), Some(&Entry(2, "b")));
     /// assert_eq!(iter.next(), None);
-    /// ```ignore
+    /// ```
     pub fn iter(&self) -> slice::Iter<'_, V> {
         self.base.iter()
-    }
-}
-
-// Index trait
-impl<K, V> Index<usize> for KeyedVecSet<K, V> {
-    type Output = V;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.base[index]
-    }
-}
-
-impl<K, V> IndexMut<usize> for KeyedVecSet<K, V> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.base[index]
     }
 }

--- a/src/keyed.rs
+++ b/src/keyed.rs
@@ -1,0 +1,1433 @@
+//! Internal backing type for `VecMap` and `VecSet`.
+//!
+//! This module provides `KeyedVecSet<K, V>`, a generic ordered collection that maintains insertion
+//! order and uses linear search for lookups.
+
+// TODO: replace ```ignore to ``` when making this module public
+
+mod impls;
+
+use super::TryReserveError;
+use alloc::vec::{self, Vec};
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::mem;
+use core::ops::{Index, IndexMut, RangeBounds};
+use core::slice;
+
+/// Key accessor for elements which have their own keys, used for `KeyedVecSet`.
+///
+/// This trait allows `KeyedVecSet` to extract keys from its elements, enabling a single
+/// implementation to work for both map-like structures (where keys and values are separate)
+/// and set-like structures (where the element is its own key).
+pub(crate) trait Keyed<K>
+where
+    K: ?Sized,
+{
+    /// Key accessor for the element.
+    fn key(&self) -> &K;
+}
+
+// For VecSet: T serves as its own key
+impl<K> Keyed<K> for K {
+    fn key(&self) -> &K {
+        self
+    }
+}
+
+/// A vector-based collection which retains the order of inserted entries.
+///
+/// Internally it is represented as a `Vec<V>`. `V` has to implement `Keyed<K>` to retrieve the key
+/// from its value.
+/// This design allows any data type to be used as an element of `KeyedVecSet`, as long as it
+/// contains data that can be considered as a key.
+///
+/// When `V = T` (where `T: Keyed<T>`), `KeyedVecSet<T, T>` is equivalent to `VecSet<T>`.
+/// When `V = Slot<K, MV>`, `KeyedVecSet<K, Slot<K, MV>>` is equivalent to `VecMap<K, MV>`.
+///
+/// # Type Parameters
+///
+/// - `K`: The key type used for lookups. Must implement `Eq` for key-based operations.
+/// - `V`: The value type, which must implement `Keyed<K>` to provide access to keys.
+#[derive(Clone, Debug)]
+pub(crate) struct KeyedVecSet<K, V> {
+    base: Vec<V>,
+    _marker: core::marker::PhantomData<K>,
+}
+
+impl<K, V> KeyedVecSet<K, V> {
+    /// Create a new set. (Does not allocate.)
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::KeyedVecSet;
+    ///
+    /// let set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
+    /// ```ignore
+    pub const fn new() -> Self {
+        KeyedVecSet {
+            base: Vec::new(),
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Create a new set with capacity for `capacity` elements. (Does not allocate if
+    /// `capacity` is zero.)
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::KeyedVecSet;
+    ///
+    /// let set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::with_capacity(10);
+    /// assert_eq!(set.len(), 0);
+    /// assert!(set.capacity() >= 10);
+    /// ```ignore
+    pub fn with_capacity(capacity: usize) -> Self {
+        KeyedVecSet {
+            base: Vec::with_capacity(capacity),
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Returns the number of elements the set can hold without reallocating.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::KeyedVecSet;
+    ///
+    /// let set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::with_capacity(10);
+    /// assert!(set.capacity() >= 10);
+    /// ```ignore
+    pub fn capacity(&self) -> usize {
+        self.base.capacity()
+    }
+
+    /// Returns the number of elements in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut a = KeyedVecSet::<i32, Entry>::new();
+    /// assert_eq!(a.len(), 0);
+    /// a.insert(Entry(1, "a"));
+    /// assert_eq!(a.len(), 1);
+    /// ```ignore
+    pub fn len(&self) -> usize {
+        self.base.len()
+    }
+
+    /// Returns `true` if the set contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut a = KeyedVecSet::<i32, Entry>::new();
+    /// assert!(a.is_empty());
+    /// a.insert(Entry(1, "a"));
+    /// assert!(!a.is_empty());
+    /// ```ignore
+    pub fn is_empty(&self) -> bool {
+        self.base.is_empty()
+    }
+
+    /// Clears the set, removing all elements.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut a = KeyedVecSet::<i32, Entry>::new();
+    /// a.insert(Entry(1, "a"));
+    /// a.clear();
+    /// assert!(a.is_empty());
+    /// ```ignore
+    pub fn clear(&mut self) {
+        self.base.clear();
+    }
+
+    /// Shortens the set, keeping the first `len` elements and dropping the rest.
+    ///
+    /// If `len` is greater than the set's current length, this has no effect.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(&'static str, i32);
+    ///
+    /// impl Keyed<&'static str> for Entry {
+    ///     fn key(&self) -> &&'static str { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<&str, Entry>::new();
+    /// map.insert(Entry("a", 1));
+    /// map.insert(Entry("b", 2));
+    /// map.insert(Entry("c", 3));
+    /// map.insert(Entry("d", 4));
+    /// map.truncate(2);
+    /// assert_eq!(map.len(), 2);
+    /// ```ignore
+    pub fn truncate(&mut self, len: usize) {
+        self.base.truncate(len);
+    }
+
+    /// Reverses the order of elements in the set, in place.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// map.reverse();
+    /// assert_eq!(map.get_index(0), Some(&Entry(3, "c")));
+    /// assert_eq!(map.get_index(1), Some(&Entry(2, "b")));
+    /// assert_eq!(map.get_index(2), Some(&Entry(1, "a")));
+    /// ```ignore
+    pub fn reverse(&mut self) {
+        self.base.reverse();
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted in the given
+    /// `KeyedVecSet<K, V>`. The collection may reserve more space to speculatively avoid frequent
+    /// reallocations. After calling `reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional`. Does nothing if capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::KeyedVecSet;
+    ///
+    /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
+    /// set.reserve(10);
+    /// assert!(set.capacity() >= 10);
+    /// ```ignore
+    pub fn reserve(&mut self, additional: usize) {
+        self.base.reserve(additional);
+    }
+
+    /// Reserves the minimum capacity for at least `additional` more elements to be inserted in
+    /// the given `KeyedVecSet<K, V>`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore,
+    /// capacity can not be relied upon to be precisely minimal. Prefer [`Self::reserve`] if future
+    /// insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::KeyedVecSet;
+    ///
+    /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
+    /// set.reserve_exact(10);
+    /// assert!(set.capacity() >= 10);
+    /// ```ignore
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.base.reserve_exact(additional);
+    }
+
+    /// Tries to reserve capacity for at least `additional` more elements to be inserted in the
+    /// given `KeyedVecSet<K, V>`. The collection may reserve more space to speculatively avoid
+    /// frequent reallocations. After calling `try_reserve`, capacity will be greater than or equal
+    /// to `self.len() + additional` if it returns `Ok(())`. Does nothing if capacity is already
+    /// sufficient. This method preserves the contents even if an error occurs.
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::KeyedVecSet;
+    ///
+    /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
+    /// set.try_reserve(10).expect("should reserve");
+    /// assert!(set.capacity() >= 10);
+    /// ```ignore
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.base.try_reserve(additional)
+    }
+
+    /// Tries to reserve the minimum capacity for at least `additional` more elements to be
+    /// inserted in the given `KeyedVecSet<K, V>`. Unlike [`Self::try_reserve`], this will not
+    /// deliberately over-allocate to speculatively avoid frequent allocations. After calling
+    /// `try_reserve_exact`, capacity will be greater than or equal to `self.len() + additional`
+    /// if it returns `Ok(())`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore,
+    /// capacity can not be relied upon to be precisely minimal. Prefer [`Self::try_reserve`] if
+    /// future insertions are expected.
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::KeyedVecSet;
+    ///
+    /// let mut set: KeyedVecSet<i32, (i32, &str)> = KeyedVecSet::new();
+    /// set.try_reserve_exact(10).expect("should reserve");
+    /// assert!(set.capacity() >= 10);
+    /// ```ignore
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.base.try_reserve_exact(additional)
+    }
+
+    /// Shrinks the capacity of the set as much as possible. It will drop down as much as possible
+    /// while maintaining the internal rules and possibly leaving some space in accordance with
+    /// the resize policy.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::with_capacity(10);
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.shrink_to_fit();
+    /// assert!(map.capacity() >= 2);
+    /// ```ignore
+    pub fn shrink_to_fit(&mut self) {
+        self.base.shrink_to_fit();
+    }
+
+    /// Shrinks the capacity of the set with a lower limit. It will drop down no lower than the
+    /// supplied limit while maintaining the internal rules and possibly leaving some space in
+    /// accordance with the resize policy.
+    ///
+    /// If the current capacity is less than the lower limit, this is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::with_capacity(10);
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.shrink_to(4);
+    /// assert!(map.capacity() >= 4);
+    /// ```ignore
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.base.shrink_to(min_capacity);
+    }
+
+    /// Splits the set into two at the given index.
+    ///
+    /// Returns a newly allocated set containing the elements in the range `[at, len)`. After the
+    /// call, the original set will be left containing the elements `[0, at)` with its previous
+    /// capacity unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// let map2 = map.split_off(1);
+    /// assert_eq!(map.len(), 1);
+    /// assert_eq!(map2.len(), 2);
+    /// ```ignore
+    pub fn split_off(&mut self, at: usize) -> KeyedVecSet<K, V> {
+        KeyedVecSet {
+            base: self.base.split_off(at),
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Removes the specified range from the vector in bulk, returning all removed elements as an
+    /// iterator. If the iterator is dropped before being fully consumed, it drops the remaining
+    /// removed elements.
+    ///
+    /// The returned iterator keeps a mutable borrow on the vector to optimize its implementation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the starting point is greater than the end point or if the end point is greater
+    /// than the length of the vector.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// let drained: Vec<_> = map.drain(1..).collect();
+    /// assert_eq!(drained, vec![Entry(2, "b"), Entry(3, "c")]);
+    /// assert_eq!(map.len(), 1);
+    /// ```ignore
+    pub fn drain<R>(&mut self, range: R) -> vec::Drain<'_, V>
+    where
+        R: RangeBounds<usize>,
+    {
+        self.base.drain(range)
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// map.retain(|entry| entry.0 % 2 == 1);
+    /// assert_eq!(map.len(), 2);
+    /// ```ignore
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&V) -> bool,
+    {
+        self.base.retain(f);
+    }
+
+    /// Retains only the elements specified by the predicate (with mutable access).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// map.retain_mut(|entry| {
+    ///     entry.0 += 10;
+    ///     entry.0 % 2 == 1
+    /// });
+    /// assert_eq!(map.len(), 2);
+    /// ```ignore
+    pub fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut V) -> bool,
+    {
+        self.base.retain_mut(f);
+    }
+
+    /// Sorts the set with a comparator function.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(3, "c"));
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.sort_by(|a, b| a.0.cmp(&b.0));
+    /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
+    /// ```ignore
+    pub fn sort_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&V, &V) -> Ordering,
+    {
+        self.base.sort_by(compare);
+    }
+
+    /// Sorts the set with a comparator function (unstable).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(3, "c"));
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
+    /// ```ignore
+    pub fn sort_unstable_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&V, &V) -> Ordering,
+    {
+        self.base.sort_unstable_by(compare);
+    }
+
+    /// Sort the set's values in place using a key extraction function.
+    ///
+    /// During sorting, the function is called at most once per entry, by using temporary storage
+    /// to remember the results of its evaluation. The order of calls to the function is
+    /// unspecified and may change between versions of `vecmap-rs` or the standard library.
+    ///
+    /// See [`slice::sort_by_cached_key`] for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(3, "c"));
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.sort_by_cached_key(|entry| entry.0);
+    /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
+    /// ```ignore
+    pub fn sort_by_cached_key<T, F>(&mut self, sort_key: F)
+    where
+        T: Ord,
+        F: FnMut(&V) -> T,
+    {
+        self.base.sort_by_cached_key(sort_key);
+    }
+
+    /// Swaps the position of two elements in the set.
+    ///
+    /// # Arguments
+    ///
+    /// * a - The index of the first element
+    /// * b - The index of the second element
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` or `b` are out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.swap_indices(0, 1);
+    /// assert_eq!(map.get_index(0), Some(&Entry(2, "b")));
+    /// assert_eq!(map.get_index(1), Some(&Entry(1, "a")));
+    /// ```ignore
+    pub fn swap_indices(&mut self, a: usize, b: usize) {
+        self.base.swap(a, b);
+    }
+
+    /// Extracts a slice containing the set elements.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// let slice = map.as_slice();
+    /// assert_eq!(slice.len(), 2);
+    /// ```ignore
+    pub fn as_slice(&self) -> &[V] {
+        self.base.as_slice()
+    }
+
+    /// Extracts a mutable slice containing the set elements.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// let slice = map.as_mut_slice();
+    /// slice[0] = Entry(3, "c");
+    /// assert_eq!(map.get_index(0), Some(&Entry(3, "c")));
+    /// ```ignore
+    pub fn as_mut_slice(&mut self) -> &mut [V] {
+        self.base.as_mut_slice()
+    }
+
+    /// Copies the set elements into a new `Vec<V>`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq, Clone)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// let vec = map.to_vec();
+    /// assert_eq!(vec, vec![Entry(1, "a"), Entry(2, "b")]);
+    /// ```ignore
+    pub fn to_vec(&self) -> Vec<V>
+    where
+        V: Clone,
+    {
+        self.base.clone()
+    }
+
+    /// Takes ownership of the set and returns its elements as a `Vec<V>`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// let vec = map.into_vec();
+    /// assert_eq!(vec, vec![Entry(1, "a"), Entry(2, "b")]);
+    /// ```ignore
+    pub fn into_vec(self) -> Vec<V> {
+        self.base
+    }
+
+    /// Takes ownership of provided vector and converts it into `KeyedVecSet`.
+    ///
+    /// # Safety
+    ///
+    /// The vector must have no duplicate keys. One way to guarantee it is to sort the vector
+    /// (e.g. by using [`[T]::sort_by_key`][slice-sort-by-key]) and then drop duplicate keys
+    /// (e.g. by using [`Vec::dedup_by_key`]).
+    ///
+    /// [slice-sort-by-key]: https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by_key
+    pub unsafe fn from_vec_unchecked(base: Vec<V>) -> Self {
+        KeyedVecSet {
+            base,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+// Lookup operations
+impl<K, V> KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+{
+    /// Return item index, if it exists in the set.
+    ///
+    /// Performs a linear search O(n) over all elements to find the matching key.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(&'static str, i32);
+    ///
+    /// impl Keyed<&'static str> for Entry {
+    ///     fn key(&self) -> &&'static str { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<&str, Entry>::new();
+    /// map.insert(Entry("a", 10));
+    /// map.insert(Entry("b", 20));
+    /// assert_eq!(map.get_index_of("a"), Some(0));
+    /// assert_eq!(map.get_index_of("b"), Some(1));
+    /// assert_eq!(map.get_index_of("c"), None);
+    /// ```ignore
+    pub fn get_index_of<Q>(&self, key: &Q) -> Option<usize>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        if self.base.is_empty() {
+            return None;
+        }
+        self.base.iter().position(|elem| elem.key().borrow() == key)
+    }
+
+    /// Returns `true` if the set contains an element with the given key.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// assert_eq!(map.contains_key(&1), true);
+    /// assert_eq!(map.contains_key(&2), false);
+    /// ```ignore
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.get_index_of(key).is_some()
+    }
+
+    /// Return a reference to the value stored for `key`, if it is present.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// assert_eq!(map.get(&1), Some(&Entry(1, "a")));
+    /// assert_eq!(map.get(&2), None);
+    /// ```ignore
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.get_index_of(key).map(|index| &self.base[index])
+    }
+
+    /// Return item index and a reference to the value stored for `key`, if it is present.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// assert_eq!(map.get_full(&1), Some((0, &Entry(1, "a"))));
+    /// assert_eq!(map.get_full(&2), None);
+    /// ```ignore
+    pub fn get_full<Q>(&self, key: &Q) -> Option<(usize, &V)>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.get_index_of(key)
+            .map(|index| (index, &self.base[index]))
+    }
+
+    /// Return a mutable reference to the value stored for `key`, if it is present.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// if let Some(entry) = map.get_mut(&1) {
+    ///     *entry = Entry(1, "b");
+    /// }
+    /// assert_eq!(map.get(&1), Some(&Entry(1, "b")));
+    /// ```ignore
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.get_index_of(key).map(|index| &mut self.base[index])
+    }
+
+    /// Return a reference to the value stored at `index`, if it is present.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// assert_eq!(map.get_index(0), Some(&Entry(1, "a")));
+    /// assert_eq!(map.get_index(1), None);
+    /// ```ignore
+    pub fn get_index(&self, index: usize) -> Option<&V> {
+        self.base.get(index)
+    }
+
+    /// Return a mutable reference to the value stored at `index`, if it is present.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// if let Some(entry) = map.get_index_mut(0) {
+    ///     *entry = Entry(2, "b");
+    /// }
+    /// assert_eq!(map.get_index(0), Some(&Entry(2, "b")));
+    /// ```ignore
+    pub fn get_index_mut(&mut self, index: usize) -> Option<&mut V> {
+        self.base.get_mut(index)
+    }
+
+    /// Get the first element.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// assert_eq!(map.first(), Some(&Entry(1, "a")));
+    /// ```ignore
+    pub fn first(&self) -> Option<&V> {
+        self.base.first()
+    }
+
+    /// Get the first element with mutable access.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// if let Some(entry) = map.first_mut() {
+    ///     *entry = Entry(3, "c");
+    /// }
+    /// assert_eq!(map.first(), Some(&Entry(3, "c")));
+    /// ```ignore
+    pub fn first_mut(&mut self) -> Option<&mut V> {
+        self.base.first_mut()
+    }
+
+    /// Get the last element.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// assert_eq!(map.last(), Some(&Entry(2, "b")));
+    /// ```ignore
+    pub fn last(&self) -> Option<&V> {
+        self.base.last()
+    }
+
+    /// Get the last element with mutable access.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// if let Some(entry) = map.last_mut() {
+    ///     *entry = Entry(3, "c");
+    /// }
+    /// assert_eq!(map.last(), Some(&Entry(3, "c")));
+    /// ```ignore
+    pub fn last_mut(&mut self) -> Option<&mut V> {
+        self.base.last_mut()
+    }
+}
+
+// Removal operations
+impl<K, V> KeyedVecSet<K, V> {
+    /// Removes the last element from the set and returns it, or [`None`] if it is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(&'static str, i32);
+    ///
+    /// impl Keyed<&'static str> for Entry {
+    ///     fn key(&self) -> &&'static str { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<&str, Entry>::new();
+    /// map.insert(Entry("a", 1));
+    /// map.insert(Entry("b", 2));
+    /// assert_eq!(map.pop(), Some(Entry("b", 2)));
+    /// assert_eq!(map.pop(), Some(Entry("a", 1)));
+    /// assert!(map.is_empty());
+    /// assert_eq!(map.pop(), None);
+    /// ```ignore
+    pub fn pop(&mut self) -> Option<V> {
+        self.base.pop()
+    }
+
+    /// Removes and returns the element at position `index`, shifting all elements after it to the left.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// assert_eq!(map.remove_index(1), Entry(2, "b"));
+    /// assert_eq!(map.len(), 2);
+    /// ```ignore
+    pub fn remove_index(&mut self, index: usize) -> V {
+        self.base.remove(index)
+    }
+
+    /// Removes an element from the set and returns it.
+    ///
+    /// The removed element is replaced by the last element of the set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// assert_eq!(map.swap_remove_index(1), Entry(2, "b"));
+    /// assert_eq!(map.len(), 2);
+    /// // Note: Entry(3, "c") moved to index 1
+    /// ```ignore
+    pub fn swap_remove_index(&mut self, index: usize) -> V {
+        self.base.swap_remove(index)
+    }
+}
+
+impl<K, V> KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+{
+    /// Remove the element equivalent to `key` and return its value.
+    ///
+    /// Like `Vec::remove`, the element is removed by shifting all of the elements that follow it,
+    /// preserving their relative order. **This perturbs the index of all of those elements!**
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// assert_eq!(map.remove(&2), Some(Entry(2, "b")));
+    /// assert_eq!(map.remove(&2), None);
+    /// ```ignore
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.get_index_of(key).map(|index| self.remove_index(index))
+    }
+
+    /// Remove the element equivalent to `key` using `swap_remove`.
+    ///
+    /// Like `Vec::swap_remove`, the element is removed by swapping it with the last element of the
+    /// set and popping it off. **This perturbs the position of what used to be the last element!**
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// map.insert(Entry(3, "c"));
+    /// map.insert(Entry(4, "d"));
+    /// assert_eq!(map.swap_remove(&2), Some(Entry(2, "b")));
+    /// assert_eq!(map.swap_remove(&2), None);
+    /// // Note: element order changed - Entry(4, "d") moved to index 1
+    /// ```ignore
+    pub fn swap_remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.get_index_of(key)
+            .map(|index| self.swap_remove_index(index))
+    }
+}
+
+// Insertion operations (unconstrained version for VecMap::push)
+impl<K, V> KeyedVecSet<K, V> {
+    /// Push a value at the end of the set.
+    pub(crate) fn push(&mut self, value: V) {
+        self.base.push(value);
+    }
+}
+
+// Insertion operations
+impl<K, V> KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Eq,
+{
+    /// Insert or replace an element (always appends new elements at the end).
+    ///
+    /// If an equivalent key already exists in the set: the key remains and retains in its place
+    /// in the order, its corresponding value is updated with `value` and the older value is
+    /// returned inside `Some(_)`.
+    ///
+    /// If no equivalent key existed in the set: the new key-value pair is inserted, last in
+    /// order, and `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// assert_eq!(map.insert(Entry(37, "a")), None);
+    /// assert_eq!(map.is_empty(), false);
+    ///
+    /// map.insert(Entry(37, "b"));
+    /// assert_eq!(map.insert(Entry(37, "c")), Some(Entry(37, "b")));
+    /// ```ignore
+    pub fn insert(&mut self, value: V) -> Option<V> {
+        self.insert_full(value).1
+    }
+
+    /// Insert or replace an element (always appends new elements at the end).
+    ///
+    /// If an equivalent key already exists in the set: the key remains and retains in its place
+    /// in the order, its corresponding value is updated with `value` and the older value is
+    /// returned inside `(index, Some(_))`.
+    ///
+    /// If no equivalent key existed in the set: the new key-value pair is inserted, last in
+    /// order, and `(index, None)` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(&'static str, i32);
+    ///
+    /// impl Keyed<&'static str> for Entry {
+    ///     fn key(&self) -> &&'static str { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<&str, Entry>::new();
+    /// assert_eq!(map.insert_full(Entry("a", 1)), (0, None));
+    /// assert_eq!(map.insert_full(Entry("b", 2)), (1, None));
+    /// assert_eq!(map.insert_full(Entry("b", 3)), (1, Some(Entry("b", 2))));
+    /// ```ignore
+    pub fn insert_full(&mut self, value: V) -> (usize, Option<V>) {
+        let key = value.key();
+        if let Some(index) = self.get_index_of(key) {
+            // Replace existing value
+            let old = mem::replace(&mut self.base[index], value);
+            (index, Some(old))
+        } else {
+            // Append new value (maintain insertion order)
+            let index = self.base.len();
+            self.base.push(value);
+            (index, None)
+        }
+    }
+
+    /// Insert a value at position `index` within the set, shifting all elements after it to the right.
+    ///
+    /// If an equivalent key already exists in the set: the key is removed from the old position and the new
+    /// value is inserted at `index`. The old index and its value are returned inside `Some((usize, V))`.
+    ///
+    /// If no equivalent key existed in the set: the new value is inserted at position `index` and `None` is returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(&'static str, i32);
+    ///
+    /// impl Keyed<&'static str> for Entry {
+    ///     fn key(&self) -> &&'static str { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<&str, Entry>::new();
+    /// assert_eq!(map.insert_at(0, Entry("a", 1)), None);
+    /// assert_eq!(map.insert_at(1, Entry("b", 2)), None);
+    /// assert_eq!(map.insert_at(0, Entry("b", 3)), Some((1, Entry("b", 2))));
+    /// ```ignore
+    pub fn insert_at(&mut self, index: usize, value: V) -> Option<(usize, V)> {
+        let key = value.key();
+        if let Some(old_index) = self.get_index_of(key) {
+            let old_value = if old_index == index {
+                mem::replace(&mut self.base[index], value)
+            } else {
+                let old_value = self.remove_index(old_index);
+                self.base.insert(index, value);
+                old_value
+            };
+            Some((old_index, old_value))
+        } else {
+            self.base.insert(index, value);
+            None
+        }
+    }
+
+    /// Moves all elements from `other` into `self`, leaving `other` empty.
+    ///
+    /// Elements from `other` that already exist in `self` are unchanged in their current position.
+    /// All other elements are appended to `self` in the order they appear in `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut a = KeyedVecSet::<i32, Entry>::new();
+    /// a.insert(Entry(3, "c"));
+    /// a.insert(Entry(2, "b"));
+    /// a.insert(Entry(1, "a"));
+    ///
+    /// let mut b = KeyedVecSet::<i32, Entry>::new();
+    /// b.insert(Entry(3, "d"));
+    /// b.insert(Entry(4, "e"));
+    /// b.insert(Entry(5, "f"));
+    ///
+    /// let old_capacity = b.capacity();
+    ///
+    /// a.append(&mut b);
+    ///
+    /// assert_eq!(a.len(), 5);
+    /// assert_eq!(b.len(), 0);
+    /// assert_eq!(b.capacity(), old_capacity);
+    /// ```ignore
+    pub fn append(&mut self, other: &mut KeyedVecSet<K, V>) {
+        self.reserve(other.len());
+        for value in other.drain(..) {
+            self.insert(value);
+        }
+    }
+}
+
+// Iterator adapters
+impl<K, V> KeyedVecSet<K, V> {
+    /// An iterator visiting all elements in insertion order. The iterator element type is `&'a V`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use vecmap::keyed::{KeyedVecSet, Keyed};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Entry(i32, &'static str);
+    ///
+    /// impl Keyed<i32> for Entry {
+    ///     fn key(&self) -> &i32 { &self.0 }
+    /// }
+    ///
+    /// let mut map = KeyedVecSet::<i32, Entry>::new();
+    /// map.insert(Entry(1, "a"));
+    /// map.insert(Entry(2, "b"));
+    /// let mut iter = map.iter();
+    /// assert_eq!(iter.next(), Some(&Entry(1, "a")));
+    /// assert_eq!(iter.next(), Some(&Entry(2, "b")));
+    /// assert_eq!(iter.next(), None);
+    /// ```ignore
+    pub fn iter(&self) -> slice::Iter<'_, V> {
+        self.base.iter()
+    }
+}
+
+// Index trait
+impl<K, V> Index<usize> for KeyedVecSet<K, V> {
+    type Output = V;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.base[index]
+    }
+}
+
+impl<K, V> IndexMut<usize> for KeyedVecSet<K, V> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.base[index]
+    }
+}

--- a/src/keyed/impls.rs
+++ b/src/keyed/impls.rs
@@ -1,0 +1,244 @@
+use super::{Keyed, KeyedVecSet};
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::ops::{Index, IndexMut};
+
+impl<K, V> Default for KeyedVecSet<K, V> {
+    fn default() -> Self {
+        KeyedVecSet::new()
+    }
+}
+
+impl<K, V, Q> Index<&Q> for KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    type Output = V;
+
+    fn index(&self, key: &Q) -> &V {
+        self.get(key).expect("KeyedVecSet: key not found")
+    }
+}
+
+impl<K, V, Q> IndexMut<&Q> for KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Borrow<Q>,
+    Q: Eq + ?Sized,
+{
+    fn index_mut(&mut self, key: &Q) -> &mut V {
+        self.get_mut(key).expect("KeyedVecSet: key not found")
+    }
+}
+
+impl<K, V> Extend<V> for KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Eq,
+{
+    fn extend<I>(&mut self, iterable: I)
+    where
+        I: IntoIterator<Item = V>,
+    {
+        let iter = iterable.into_iter();
+        let reserve = if self.is_empty() {
+            iter.size_hint().0
+        } else {
+            // Round up but make sure we don't overflow when size_hint ==
+            // usize::MAX.
+            let size_hint = iter.size_hint().0;
+            size_hint / 2 + size_hint % 2
+        };
+        self.reserve(reserve);
+        iter.for_each(move |value| {
+            self.insert(value);
+        });
+    }
+}
+
+impl<'a, K, V: Clone> Extend<&'a V> for KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Eq,
+{
+    fn extend<I>(&mut self, iterable: I)
+    where
+        I: IntoIterator<Item = &'a V>,
+    {
+        self.extend(iterable.into_iter().cloned());
+    }
+}
+
+impl<K, V> FromIterator<V> for KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Eq,
+{
+    fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let lower = iter.size_hint().0;
+        let mut set = KeyedVecSet::with_capacity(lower);
+        set.extend(iter);
+        set
+    }
+}
+
+impl<K, V> From<Vec<V>> for KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Eq,
+{
+    /// Constructs set from a vector of values.
+    ///
+    /// **Note**: This conversion has a quadratic complexity because the
+    /// conversion preserves order of elements while at the same time having to
+    /// make sure no duplicate keys exist. To avoid it, sort and deduplicate
+    /// the vector and use [`KeyedVecSet::from_vec_unchecked`] instead.
+    fn from(mut vec: Vec<V>) -> Self {
+        crate::dedup(&mut vec, |rhs, lhs| rhs.key() == lhs.key());
+        // SAFETY: We've just deduplicated the elements.
+        unsafe { Self::from_vec_unchecked(vec) }
+    }
+}
+
+impl<K, V> From<&[V]> for KeyedVecSet<K, V>
+where
+    V: Clone + Keyed<K>,
+    K: Eq,
+{
+    fn from(slice: &[V]) -> Self {
+        KeyedVecSet::from_iter(slice.iter().cloned())
+    }
+}
+
+impl<K, V> From<&mut [V]> for KeyedVecSet<K, V>
+where
+    V: Clone + Keyed<K>,
+    K: Eq,
+{
+    fn from(slice: &mut [V]) -> Self {
+        KeyedVecSet::from_iter(slice.iter().cloned())
+    }
+}
+
+impl<K, V, const N: usize> From<[V; N]> for KeyedVecSet<K, V>
+where
+    V: Keyed<K>,
+    K: Eq,
+{
+    fn from(arr: [V; N]) -> Self {
+        KeyedVecSet::from_iter(arr)
+    }
+}
+
+impl<K, V> PartialEq for KeyedVecSet<K, V>
+where
+    V: Keyed<K> + PartialEq,
+    K: Eq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        self.iter()
+            .all(|value| other.get(value.key()).is_some_and(|v| *value == *v))
+    }
+}
+
+impl<K, V> Eq for KeyedVecSet<K, V>
+where
+    V: Keyed<K> + Eq,
+    K: Eq,
+{
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate alloc;
+    use alloc::vec;
+
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    struct Entry(i32, &'static str);
+
+    impl Keyed<i32> for Entry {
+        fn key(&self) -> &i32 {
+            &self.0
+        }
+    }
+
+    #[test]
+    fn default() {
+        let set: KeyedVecSet<i32, Entry> = KeyedVecSet::default();
+        assert_eq!(set.len(), 0);
+    }
+
+    #[test]
+    fn index_by_key() {
+        let mut set = KeyedVecSet::<i32, Entry>::new();
+        set.insert(Entry(1, "a"));
+        assert_eq!(set[&1], Entry(1, "a"));
+    }
+
+    #[test]
+    #[should_panic(expected = "KeyedVecSet: key not found")]
+    fn index_by_key_not_found() {
+        let set: KeyedVecSet<i32, Entry> = KeyedVecSet::new();
+        let _ = &set[&1];
+    }
+
+    #[test]
+    fn index_mut_by_key() {
+        let mut set = KeyedVecSet::<i32, Entry>::new();
+        set.insert(Entry(1, "a"));
+        set[&1] = Entry(1, "b");
+        assert_eq!(set[&1], Entry(1, "b"));
+    }
+
+    #[test]
+    fn extend() {
+        let mut set = KeyedVecSet::<i32, Entry>::new();
+        set.extend(vec![Entry(1, "a"), Entry(2, "b")]);
+        assert_eq!(set.len(), 2);
+        assert_eq!(set[&1], Entry(1, "a"));
+    }
+
+    #[test]
+    fn from_vec() {
+        let set =
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a"), Entry(2, "b"), Entry(1, "c")]);
+        assert_eq!(set.len(), 2);
+        assert_eq!(set[&1], Entry(1, "a"));
+    }
+
+    #[test]
+    fn eq() {
+        assert_ne!(
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a")]),
+            KeyedVecSet::<i32, Entry>::from(vec![])
+        );
+        assert_ne!(
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a")]),
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(2, "b")])
+        );
+        assert_eq!(
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a")]),
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a")])
+        );
+        assert_ne!(
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a")]),
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a"), Entry(2, "b")])
+        );
+        assert_eq!(
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a"), Entry(2, "b")]),
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a"), Entry(2, "b")])
+        );
+        assert_eq!(
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a"), Entry(2, "b")]),
+            KeyedVecSet::<i32, Entry>::from(vec![Entry(2, "b"), Entry(1, "a")])
+        );
+    }
+}

--- a/src/keyed/impls.rs
+++ b/src/keyed/impls.rs
@@ -33,6 +33,20 @@ where
     }
 }
 
+impl<K, V> Index<usize> for KeyedVecSet<K, V> {
+    type Output = V;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.base[index]
+    }
+}
+
+impl<K, V> IndexMut<usize> for KeyedVecSet<K, V> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.base[index]
+    }
+}
+
 impl<K, V> Extend<V> for KeyedVecSet<K, V>
 where
     V: Keyed<K>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 
 #[macro_use]
 mod macros;
+mod keyed;
 pub mod map;
 pub mod set;
 
@@ -32,6 +33,13 @@ use alloc::vec::Vec;
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Slot<K, V> {
     data: (K, V),
+}
+
+impl<K, V> keyed::Keyed<K> for Slot<K, V> {
+    #[inline]
+    fn key(&self) -> &K {
+        &self.data.0
+    }
 }
 
 impl<K, V> Slot<K, V> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1490,12 +1490,7 @@ impl<K, V> Entries for VecMap<K, V> {
     }
 
     fn as_entries_mut(&mut self) -> &mut [Self::Entry] {
-        unsafe {
-            core::slice::from_raw_parts_mut(
-                self.base.as_slice().as_ptr().cast_mut(),
-                self.base.len(),
-            )
-        }
+        self.base.as_mut_slice()
     }
 
     fn into_entries(self) -> Vec<Self::Entry> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -7,11 +7,10 @@ mod mutable_keys;
 #[cfg(feature = "serde")]
 mod serde;
 
-use super::{Entries, Slot, TryReserveError};
+use super::{keyed::KeyedVecSet, Entries, Slot, TryReserveError};
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp::Ordering;
-use core::mem;
 use core::ops::RangeBounds;
 use core::ptr;
 
@@ -25,7 +24,7 @@ pub use self::mutable_keys::MutableKeys;
 /// `Ord`.
 #[derive(Clone, Debug)]
 pub struct VecMap<K, V> {
-    pub(crate) base: Vec<Slot<K, V>>,
+    base: KeyedVecSet<K, Slot<K, V>>,
 }
 
 impl<K, V> VecMap<K, V> {
@@ -39,7 +38,9 @@ impl<K, V> VecMap<K, V> {
     /// let mut map: VecMap<i32, &str> = VecMap::new();
     /// ```
     pub const fn new() -> Self {
-        VecMap { base: Vec::new() }
+        VecMap {
+            base: KeyedVecSet::new(),
+        }
     }
 
     /// Create a new map with capacity for `capacity` key-value pairs. (Does not allocate if
@@ -56,7 +57,7 @@ impl<K, V> VecMap<K, V> {
     /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         VecMap {
-            base: Vec::with_capacity(capacity),
+            base: KeyedVecSet::with_capacity(capacity),
         }
     }
 
@@ -688,7 +689,7 @@ impl<K, V> VecMap<K, V> {
     /// ```
     pub fn into_vec(self) -> Vec<(K, V)> {
         // SAFETY: `Vec<Slot<K, V>>` and `Vec<(K, V)>` have the same memory layout.
-        unsafe { super::transmute_vec(self.base) }
+        unsafe { super::transmute_vec(self.base.into_vec()) }
     }
 
     /// Takes ownership of provided vector and converts it into `VecMap`.
@@ -716,8 +717,10 @@ impl<K, V> VecMap<K, V> {
     /// [slice-sort-by-key]: https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by_key
     pub unsafe fn from_vec_unchecked(vec: Vec<(K, V)>) -> Self {
         // SAFETY: `Vec<(K, V)>` and `Vec<Slot<K, V>>` have the same memory layout.
-        let base = unsafe { super::transmute_vec(vec) };
-        VecMap { base }
+        let base_vec = unsafe { super::transmute_vec(vec) };
+        VecMap {
+            base: unsafe { KeyedVecSet::from_vec_unchecked(base_vec) },
+        }
     }
 }
 
@@ -740,7 +743,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key).is_some()
+        self.base.contains_key(key)
     }
 
     /// Get the first key-value pair.
@@ -825,7 +828,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key).map(|index| self.base[index].value())
+        self.base.get(key).map(Slot::value)
     }
 
     /// Return a mutable reference to the value stored for `key`, if it is present, else `None`.
@@ -847,8 +850,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key)
-            .map(|index| self.base[index].value_mut())
+        self.base.get_mut(key).map(super::Slot::value_mut)
     }
 
     /// Return references to the key-value pair stored at `index`, if it is present, else `None`.
@@ -864,7 +866,7 @@ impl<K, V> VecMap<K, V> {
     /// assert_eq!(map.get_index(1), None);
     /// ```
     pub fn get_index(&self, index: usize) -> Option<(&K, &V)> {
-        self.base.get(index).map(Slot::refs)
+        self.base.get_index(index).map(Slot::refs)
     }
 
     /// Return a reference to the key and a mutable reference to the value stored at `index`, if it
@@ -883,7 +885,7 @@ impl<K, V> VecMap<K, V> {
     /// assert_eq!(map[0], "b");
     /// ```
     pub fn get_index_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
-        self.base.get_mut(index).map(Slot::ref_mut)
+        self.base.get_index_mut(index).map(Slot::ref_mut)
     }
 
     /// Return the index and references to the key-value pair stored for `key`, if it is present,
@@ -904,10 +906,9 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key).map(|index| {
-            let (key, value) = self.base[index].refs();
-            (index, key, value)
-        })
+        self.base
+            .get_full(key)
+            .map(|(index, slot)| (index, slot.key(), slot.value()))
     }
 
     /// Return the index, a reference to the key and a mutable reference to the value stored for
@@ -931,7 +932,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key).map(|index| {
+        self.base.get_index_of(key).map(|index| {
             let (key, value) = self.base[index].ref_mut();
             (index, key, value)
         })
@@ -954,7 +955,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key).map(|index| self.base[index].refs())
+        self.base.get(key).map(Slot::refs)
     }
 
     /// Return item index, if it exists in the map.
@@ -976,11 +977,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        if self.base.is_empty() {
-            return None;
-        }
-
-        self.base.iter().position(|slot| slot.key().borrow() == key)
+        self.base.get_index_of(key)
     }
 }
 
@@ -1024,8 +1021,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key)
-            .map(|index| self.remove_index(index).1)
+        self.base.remove(key).map(Slot::into_value)
     }
 
     /// Remove and return the key-value pair equivalent to `key`.
@@ -1048,7 +1044,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key).map(|index| self.remove_index(index))
+        self.base.remove(key).map(Slot::into_key_value)
     }
 
     /// Removes and returns the key-value pair at position `index` within the map, shifting all
@@ -1072,7 +1068,7 @@ impl<K, V> VecMap<K, V> {
     /// assert_eq!(v, VecMap::from([("a", 1), ("c", 3)]));
     /// ```
     pub fn remove_index(&mut self, index: usize) -> (K, V) {
-        self.base.remove(index).into_key_value()
+        self.base.remove_index(index).into_key_value()
     }
 
     /// Remove the key-value pair equivalent to `key` and return its value.
@@ -1095,8 +1091,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key)
-            .map(|index| self.swap_remove_index(index).1)
+        self.base.swap_remove(key).map(Slot::into_value)
     }
 
     /// Remove and return the key-value pair equivalent to `key`.
@@ -1119,8 +1114,7 @@ impl<K, V> VecMap<K, V> {
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        self.get_index_of(key)
-            .map(|index| self.swap_remove_index(index))
+        self.base.swap_remove(key).map(Slot::into_key_value)
     }
 
     /// Removes a key-value pair from the map and returns it.
@@ -1149,7 +1143,7 @@ impl<K, V> VecMap<K, V> {
     /// assert_eq!(v, VecMap::from([("baz", 3), ("bar", 2)]));
     /// ```
     pub fn swap_remove_index(&mut self, index: usize) -> (K, V) {
-        self.base.swap_remove(index).into_key_value()
+        self.base.swap_remove_index(index).into_key_value()
     }
 
     /// Swaps the position of two key-value pairs in the map.
@@ -1173,7 +1167,7 @@ impl<K, V> VecMap<K, V> {
     /// assert_eq!(map.to_vec(), [("a", 1), ("d", 4), ("c", 3), ("b", 2)]);
     /// ```
     pub fn swap_indices(&mut self, a: usize, b: usize) {
-        self.base.swap(a, b);
+        self.base.swap_indices(a, b);
     }
 }
 
@@ -1235,13 +1229,8 @@ where
     /// assert_eq!(map["b"], 3);
     /// ```
     pub fn insert_full(&mut self, key: K, value: V) -> (usize, Option<V>) {
-        match self.get_index_of(&key) {
-            Some(index) => {
-                let old_slot = mem::replace(&mut self.base[index], Slot::new(key, value));
-                (index, Some(old_slot.into_value()))
-            }
-            None => (self.push(key, value), None),
-        }
+        let (index, old_slot) = self.base.insert_full(Slot::new(key, value));
+        (index, old_slot.map(Slot::into_value))
     }
 
     /// Insert a key-value pair at position `index` within the map, shifting all
@@ -1270,20 +1259,9 @@ where
     /// assert_eq!(map.to_vec(), [("b", 3), ("a", 1)]);
     /// ```
     pub fn insert_at(&mut self, index: usize, key: K, value: V) -> Option<(usize, V)> {
-        if let Some(old_index) = self.get_index_of(&key) {
-            let old_slot = if old_index == index {
-                mem::replace(&mut self.base[index], Slot::new(key, value))
-            } else {
-                let old_slot = self.base.remove(old_index);
-                self.base.insert(index, Slot::new(key, value));
-                old_slot
-            };
-
-            Some((old_index, old_slot.into_value()))
-        } else {
-            self.base.insert(index, Slot::new(key, value));
-            None
-        }
+        self.base
+            .insert_at(index, Slot::new(key, value))
+            .map(|(old_index, old_slot)| (old_index, old_slot.into_value()))
     }
 
     /// Get the given key's corresponding entry in the map for insertion and/or in-place
@@ -1338,7 +1316,7 @@ where
     /// assert_eq!(a[&3], "d"); // "c" was overwritten.
     /// ```
     pub fn append(&mut self, other: &mut VecMap<K, V>) {
-        self.extend(other.drain(..));
+        self.base.append(&mut other.base);
     }
 }
 
@@ -1508,14 +1486,19 @@ impl<K, V> Entries for VecMap<K, V> {
     type Entry = Slot<K, V>;
 
     fn as_entries(&self) -> &[Self::Entry] {
-        &self.base
+        self.base.as_slice()
     }
 
     fn as_entries_mut(&mut self) -> &mut [Self::Entry] {
-        &mut self.base
+        unsafe {
+            core::slice::from_raw_parts_mut(
+                self.base.as_slice().as_ptr().cast_mut(),
+                self.base.len(),
+            )
+        }
     }
 
     fn into_entries(self) -> Vec<Self::Entry> {
-        self.base
+        self.base.into_vec()
     }
 }

--- a/src/map/impls.rs
+++ b/src/map/impls.rs
@@ -57,19 +57,8 @@ where
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let iter = iterable.into_iter();
-        let reserve = if self.is_empty() {
-            iter.size_hint().0
-        } else {
-            // Round up but make sure we don’t overflow when size_hint ==
-            // usize::MAX.
-            let size_hint = iter.size_hint().0;
-            size_hint / 2 + size_hint % 2
-        };
-        self.reserve(reserve);
-        iter.for_each(move |(k, v)| {
-            self.insert(k, v);
-        });
+        self.base
+            .extend(iterable.into_iter().map(|(k, v)| crate::Slot::new(k, v)));
     }
 }
 
@@ -164,12 +153,7 @@ where
     V: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        if self.len() != other.len() {
-            return false;
-        }
-
-        self.iter()
-            .all(|(key, value)| other.get(key).is_some_and(|v| *value == *v))
+        self.base == other.base
     }
 }
 

--- a/src/map/iter.rs
+++ b/src/map/iter.rs
@@ -369,10 +369,6 @@ impl<'a, K, V> Drain<'a, K, V> {
             iter: map.base.drain(range),
         }
     }
-
-    pub(crate) fn as_slice(&self) -> &[Slot<K, V>] {
-        self.iter.as_slice()
-    }
 }
 
 impl_iterator!(Drain<'a, K, V>, (K, V), Slot::into_key_value, Slot::refs);

--- a/src/map/mutable_keys.rs
+++ b/src/map/mutable_keys.rs
@@ -141,13 +141,17 @@ impl<K, V> MutableKeys for VecMap<K, V> {
         Q: Eq + ?Sized,
     {
         self.get_index_of(key).map(|index| {
-            let (key, value) = self.base[index].muts();
+            let (key, value) = self
+                .base
+                .get_index_mut(index)
+                .expect("index should exist")
+                .muts();
             (index, key, value)
         })
     }
 
     fn get_index_mut2(&mut self, index: usize) -> Option<(&mut K, &mut V)> {
-        self.base.get_mut(index).map(Slot::muts)
+        self.base.get_index_mut(index).map(Slot::muts)
     }
 
     fn retain2<F>(&mut self, mut f: F)

--- a/src/map/mutable_keys.rs
+++ b/src/map/mutable_keys.rs
@@ -141,11 +141,7 @@ impl<K, V> MutableKeys for VecMap<K, V> {
         Q: Eq + ?Sized,
     {
         self.get_index_of(key).map(|index| {
-            let (key, value) = self
-                .base
-                .get_index_mut(index)
-                .expect("index should exist")
-                .muts();
+            let (key, value) = self.base[index].muts();
             (index, key, value)
         })
     }

--- a/src/set/impls.rs
+++ b/src/set/impls.rs
@@ -50,7 +50,7 @@ where
         I: IntoIterator<Item = T>,
     {
         VecSet {
-            base: iter.into_iter().collect(),
+            base: super::KeyedVecSet::from_iter(iter),
         }
     }
 }
@@ -66,9 +66,7 @@ where
     /// make sure no duplicate elements exist. To avoid it, sort and deduplicate
     /// the vector and use [`VecSet::from_vec_unchecked`] instead.
     fn from(vec: Vec<T>) -> Self {
-        VecSet {
-            base: vec.into(),
-        }
+        VecSet { base: vec.into() }
     }
 }
 
@@ -77,9 +75,7 @@ where
     T: Clone + Eq,
 {
     fn from(slice: &[T]) -> Self {
-        VecSet {
-            base: slice.into(),
-        }
+        VecSet { base: slice.into() }
     }
 }
 
@@ -88,9 +84,7 @@ where
     T: Clone + Eq,
 {
     fn from(slice: &mut [T]) -> Self {
-        VecSet {
-            base: slice.into(),
-        }
+        VecSet { base: slice.into() }
     }
 }
 

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -1,5 +1,4 @@
-use super::{Entries, Slot, VecSet};
-use crate::map;
+use super::{Entries, VecSet};
 use alloc::vec::{self, Vec};
 use core::fmt;
 use core::iter::{Chain, FusedIterator};
@@ -75,11 +74,11 @@ impl<'a, T> IntoIterator for &'a VecSet<T> {
 ///
 /// [`iter`]: VecSet::iter
 pub struct Iter<'a, T> {
-    iter: slice::Iter<'a, Slot<T, ()>>,
+    iter: slice::Iter<'a, T>,
 }
 
 impl<'a, T> Iter<'a, T> {
-    pub(super) fn new(entries: &'a [Slot<T, ()>]) -> Iter<'a, T> {
+    pub(super) fn new(entries: &'a [T]) -> Iter<'a, T> {
         Iter {
             iter: entries.iter(),
         }
@@ -94,7 +93,7 @@ impl<T> Clone for Iter<'_, T> {
     }
 }
 
-impl_iterator!(Iter<'a, T>, &'a T, Slot::key);
+impl_iterator!(Iter<'a, T>, &'a T, |x| x);
 
 /// An owning iterator over the elements of a `VecSet`.
 ///
@@ -104,11 +103,11 @@ impl_iterator!(Iter<'a, T>, &'a T, Slot::key);
 /// [`into_iter`]: IntoIterator::into_iter
 /// [`IntoIterator`]: core::iter::IntoIterator
 pub struct IntoIter<T> {
-    iter: vec::IntoIter<Slot<T, ()>>,
+    iter: vec::IntoIter<T>,
 }
 
 impl<T> IntoIter<T> {
-    pub(super) fn new(entries: Vec<Slot<T, ()>>) -> IntoIter<T> {
+    pub(super) fn new(entries: Vec<T>) -> IntoIter<T> {
         IntoIter {
             iter: entries.into_iter(),
         }
@@ -126,7 +125,7 @@ where
     }
 }
 
-impl_iterator!(IntoIter<T>, T, Slot::into_key, Slot::key);
+impl_iterator!(IntoIter<T>, T, |x| x);
 
 /// A lazy iterator producing elements in the difference of `VecSet`s.
 ///
@@ -418,7 +417,7 @@ where
 ///
 /// [`drain`]: VecSet::drain
 pub struct Drain<'a, T> {
-    iter: map::Drain<'a, T, ()>,
+    iter: vec::Drain<'a, T>,
 }
 
 impl<'a, T> Drain<'a, T> {
@@ -432,4 +431,4 @@ impl<'a, T> Drain<'a, T> {
     }
 }
 
-impl_iterator!(Drain<'a, T>, T, |(k, ())| k, Slot::key);
+impl_iterator!(Drain<'a, T>, T, |x| x);

--- a/src/set/iter.rs
+++ b/src/set/iter.rs
@@ -6,15 +6,12 @@ use core::ops::RangeBounds;
 use core::slice;
 
 macro_rules! impl_iterator {
-    ($ty:ident<$($lt:lifetime,)*$($gen:ident),+>, $item:ty, $map:expr) => {
-        impl_iterator!($ty<$($lt,)*$($gen),+>, $item, $map, $map);
-    };
-    ($ty:ident<$($lt:lifetime,)*$($gen:ident),+>, $item:ty, $map:expr, $debug_map:expr) => {
+    ($ty:ident<$($lt:lifetime,)*$($gen:ident),+>, $item:ty) => {
         impl<$($lt,)*$($gen),+> Iterator for $ty<$($lt,)*$($gen),+> {
             type Item = $item;
 
             fn next(&mut self) -> Option<Self::Item> {
-                self.iter.next().map($map)
+                self.iter.next()
             }
 
             fn size_hint(&self) -> (usize, Option<usize>) {
@@ -24,7 +21,7 @@ macro_rules! impl_iterator {
 
         impl<$($lt,)*$($gen),+> DoubleEndedIterator for $ty<$($lt,)*$($gen),+> {
             fn next_back(&mut self) -> Option<Self::Item> {
-                self.iter.next_back().map($map)
+                self.iter.next_back()
             }
         }
 
@@ -41,7 +38,7 @@ macro_rules! impl_iterator {
             T: fmt::Debug,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let iter = self.iter.as_slice().iter().map($debug_map);
+                let iter = self.iter.as_slice().iter();
                 f.debug_list().entries(iter).finish()
             }
         }
@@ -93,7 +90,7 @@ impl<T> Clone for Iter<'_, T> {
     }
 }
 
-impl_iterator!(Iter<'a, T>, &'a T, |x| x);
+impl_iterator!(Iter<'a, T>, &'a T);
 
 /// An owning iterator over the elements of a `VecSet`.
 ///
@@ -125,7 +122,7 @@ where
     }
 }
 
-impl_iterator!(IntoIter<T>, T, |x| x);
+impl_iterator!(IntoIter<T>, T);
 
 /// A lazy iterator producing elements in the difference of `VecSet`s.
 ///
@@ -431,4 +428,4 @@ impl<'a, T> Drain<'a, T> {
     }
 }
 
-impl_iterator!(Drain<'a, T>, T, |x| x);
+impl_iterator!(Drain<'a, T>, T);


### PR DESCRIPTION
This is Step 1 of #47 

`KeyedVecSet` is added as an internal representation of `VecMap` and `VecSet`.

`keyed/impls.rs` is added, but missing `keyed/entry.rs`, `keyed/iter.rs`, `keyed/mutable_keys.rs`, and `keyed/serde.rs`

----

Introduce KeyedVecSet<K, V> as a shared backing implementation for both VecMap and VecSet to reduce code duplication.

Key changes:
- Add src/keyed.rs with KeyedVecSet and Keyed<K> trait
- VecMap now uses KeyedVecSet<K, Slot<K, V>>
- VecSet now uses KeyedVecSet<T, T> (removes VecMap dependency)
- Simplify VecMap and VecSet to thin wrappers

Public API unchanged.