### PR TITLE
Upgrade to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/vecmap-rs/"
 keywords = ["vector", "map", "set", "vec", "no-std"]
 categories = ["data-structures", "no-std"]
 readme = "README.md"
-edition = "2021"
+edition = "2024"
 exclude = [
     ".github/",
 ]

--- a/src/keyed/impls.rs
+++ b/src/keyed/impls.rs
@@ -123,7 +123,7 @@ where
     K: Eq,
 {
     fn from(slice: &[V]) -> Self {
-        KeyedVecSet::from_iter(slice.iter().cloned())
+        slice.iter().cloned().collect()
     }
 }
 
@@ -133,7 +133,7 @@ where
     K: Eq,
 {
     fn from(slice: &mut [V]) -> Self {
-        KeyedVecSet::from_iter(slice.iter().cloned())
+        slice.iter().cloned().collect()
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -7,7 +7,7 @@ mod mutable_keys;
 #[cfg(feature = "serde")]
 mod serde;
 
-use super::{keyed::KeyedVecSet, Entries, Slot, TryReserveError};
+use super::{Entries, Slot, TryReserveError, keyed::KeyedVecSet};
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp::Ordering;

--- a/src/map/serde.rs
+++ b/src/map/serde.rs
@@ -73,7 +73,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde_test::{assert_tokens, Token};
+    use serde_test::{Token, assert_tokens};
 
     #[test]
     fn ser_de_empty() {

--- a/src/set.rs
+++ b/src/set.rs
@@ -5,7 +5,7 @@ mod iter;
 #[cfg(feature = "serde")]
 mod serde;
 
-use super::{keyed::KeyedVecSet, Entries, TryReserveError};
+use super::{Entries, TryReserveError, keyed::KeyedVecSet};
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp::Ordering;

--- a/src/set/serde.rs
+++ b/src/set/serde.rs
@@ -69,7 +69,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde_test::{assert_tokens, Token};
+    use serde_test::{Token, assert_tokens};
 
     #[test]
     fn ser_de_empty() {


### PR DESCRIPTION
for this project, edition affects a lot to `cargo test` speed

edition 2021
```
time cargo test > /dev/null 
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/vecmap-e7467bed5d40b8ad)
   Doc-tests vecmap
cargo test > /dev/null  14.88s user 7.99s system 45% cpu 49.809 total
```

edition 2024
```
time cargo test > /dev/null
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/vecmap-e7467bed5d40b8ad)
   Doc-tests vecmap
cargo test > /dev/null  0.77s user 0.27s system 98% cpu 1.058 total
```