### PR TITLE
Fix inconsistent duplicate handling across construction paths

### DIFF
--- a/src/keyed/impls.rs
+++ b/src/keyed/impls.rs
@@ -106,12 +106,17 @@ where
 {
     /// Constructs set from a vector of values.
     ///
+    /// When the input contains duplicate keys, the first insertion position is
+    /// kept and the last associated value wins — the same rule as
+    /// [`insert`][KeyedVecSet::insert], [`extend`][Extend::extend], and
+    /// [`FromIterator`].
+    ///
     /// **Note**: This conversion has a quadratic complexity because the
     /// conversion preserves order of elements while at the same time having to
     /// make sure no duplicate keys exist. To avoid it, sort and deduplicate
     /// the vector and use [`KeyedVecSet::from_vec_unchecked`] instead.
     fn from(mut vec: Vec<V>) -> Self {
-        crate::dedup(&mut vec, |rhs, lhs| rhs.key() == lhs.key());
+        crate::dedup_keep_last_value(&mut vec, |lhs, rhs| lhs.key() == rhs.key());
         // SAFETY: We've just deduplicated the elements.
         unsafe { Self::from_vec_unchecked(vec) }
     }
@@ -225,7 +230,39 @@ mod test {
         let set =
             KeyedVecSet::<i32, Entry>::from(vec![Entry(1, "a"), Entry(2, "b"), Entry(1, "c")]);
         assert_eq!(set.len(), 2);
-        assert_eq!(set[&1], Entry(1, "a"));
+        assert_eq!(set[&1], Entry(1, "c"));
+    }
+
+    fn set_via_inserts(entries: &[Entry]) -> KeyedVecSet<i32, Entry> {
+        let mut set = KeyedVecSet::new();
+        for entry in entries {
+            set.insert(entry.clone());
+        }
+        set
+    }
+
+    #[test]
+    fn constructor_parity_with_insert() {
+        let input = vec![Entry(1, "a"), Entry(2, "b"), Entry(1, "c")];
+        let expected = set_via_inserts(&[Entry(1, "a"), Entry(2, "b"), Entry(1, "c")]);
+
+        assert_eq!(KeyedVecSet::from(input.clone()), expected);
+        assert_eq!(input.into_iter().collect::<KeyedVecSet<_, _>>(), expected);
+        assert_eq!(
+            KeyedVecSet::from([Entry(1, "a"), Entry(2, "b"), Entry(1, "c")]),
+            expected
+        );
+        assert_eq!(expected.get(&1), Some(&Entry(1, "c")));
+        assert_eq!(expected.as_slice(), &[Entry(1, "c"), Entry(2, "b")]);
+    }
+
+    #[test]
+    fn extend_parity_with_insert() {
+        let mut via_extend = KeyedVecSet::new();
+        via_extend.extend(vec![Entry(1, "a"), Entry(2, "b"), Entry(1, "c")]);
+
+        let via_insert = set_via_inserts(&[Entry(1, "a"), Entry(2, "b"), Entry(1, "c")]);
+        assert_eq!(via_extend, via_insert);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,12 +110,32 @@ trait Entries {
     fn into_entries(self) -> Vec<Self::Entry>;
 }
 
-/// Deduplicate elements in an unsorted vector.
-fn dedup<T>(vec: &mut Vec<T>, eq_fn: impl Fn(&T, &T) -> bool) {
+/// Deduplicate elements in an unsorted vector, keeping the first occurrence of
+/// each equivalence class.
+fn dedup_keep_first<T>(vec: &mut Vec<T>, eq_fn: impl Fn(&T, &T) -> bool) {
     let mut out = 1;
     let len = vec.len();
     for i in 1..len {
         if (0..i).all(|j| !eq_fn(&vec[i], &vec[j])) {
+            vec.swap(out, i);
+            out += 1;
+        }
+    }
+    vec.truncate(out);
+}
+
+/// Deduplicate by equivalence, keeping the first occurrence's position but the
+/// last occurrence's value.
+fn dedup_keep_last_value<T>(vec: &mut Vec<T>, eq_fn: impl Fn(&T, &T) -> bool) {
+    if vec.len() <= 1 {
+        return;
+    }
+    let mut out = 1;
+    let len = vec.len();
+    for i in 1..len {
+        if let Some(j) = (0..out).find(|&j| eq_fn(&vec[i], &vec[j])) {
+            vec.swap(i, j);
+        } else {
             vec.swap(out, i);
             out += 1;
         }
@@ -136,10 +156,10 @@ unsafe fn transmute_vec<T, U>(mut vec: Vec<T>) -> Vec<U> {
 }
 
 #[test]
-fn test_dedup() {
+fn test_dedup_keep_first() {
     fn test(want: &[u32], arr: &[u32]) {
         let mut vec = arr.to_vec();
-        dedup(&mut vec, |i, j| i == j);
+        dedup_keep_first(&mut vec, |i, j| i == j);
         assert_eq!(want, vec.as_slice());
     }
 
@@ -149,6 +169,59 @@ fn test_dedup() {
     test(&[1], &[1, 1, 1]);
     test(&[3, 1, 2], &[3, 1, 2]);
     test(&[3, 1, 2], &[3, 1, 2, 1, 2, 3]);
+}
+
+#[test]
+fn test_dedup_keep_first_preserves_first_payload() {
+    #[derive(Clone, Debug)]
+    #[allow(dead_code)]
+    struct Item(i32, &'static str);
+
+    impl Eq for Item {}
+
+    impl PartialEq for Item {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    let mut vec = Vec::from([Item(1, "first"), Item(2, "b"), Item(1, "second")]);
+    dedup_keep_first(&mut vec, |a, b| a == b);
+    assert_eq!(vec, [Item(1, "first"), Item(2, "b")]);
+}
+
+#[test]
+fn test_dedup_keep_last_value() {
+    fn test(want: &[(char, i32)], arr: &[(char, i32)]) {
+        let mut vec = arr.to_vec();
+        dedup_keep_last_value(&mut vec, |lhs, rhs| lhs.0 == rhs.0);
+        assert_eq!(want, vec.as_slice());
+    }
+
+    test(&[], &[]);
+    test(&[('a', 1)], &[('a', 1)]);
+    test(&[('a', 3)], &[('a', 1), ('a', 2), ('a', 3)]);
+    test(&[('a', 3), ('b', 2)], &[('a', 1), ('b', 2), ('a', 3)]);
+    test(&[('b', 2), ('a', 1)], &[('b', 2), ('a', 1)]);
+}
+
+#[test]
+fn test_dedup_keep_last_value_preserves_last_payload() {
+    #[derive(Clone, Debug)]
+    #[allow(dead_code)]
+    struct Entry(i32, &'static str);
+
+    impl Eq for Entry {}
+
+    impl PartialEq for Entry {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    let mut vec = Vec::from([Entry(1, "a"), Entry(2, "b"), Entry(1, "c")]);
+    dedup_keep_last_value(&mut vec, |lhs, rhs| lhs.0 == rhs.0);
+    assert_eq!(vec, [Entry(1, "c"), Entry(2, "b")]);
 }
 
 // https://github.com/martinohmann/vecmap-rs/issues/18

--- a/src/map/impls.rs
+++ b/src/map/impls.rs
@@ -105,12 +105,17 @@ where
 {
     /// Constructs map from a vector of `(key → value)` pairs.
     ///
+    /// When the input contains duplicate keys, the first insertion position is
+    /// kept and the last associated value wins — the same rule as
+    /// [`insert`][VecMap::insert], [`extend`][Extend::extend], and
+    /// [`FromIterator`].
+    ///
     /// **Note**: This conversion has a quadratic complexity because the
     /// conversion preserves order of elements while at the same time having to
     /// make sure no duplicate keys exist. To avoid it, sort and deduplicate
     /// the vector and use [`VecMap::from_vec_unchecked`] instead.
     fn from(mut vec: Vec<(K, V)>) -> Self {
-        crate::dedup(&mut vec, |rhs, lhs| rhs.0 == lhs.0);
+        crate::dedup_keep_last_value(&mut vec, |lhs, rhs| lhs.0 == rhs.0);
         // SAFETY: We've just deduplicated the elements.
         unsafe { Self::from_vec_unchecked(vec) }
     }
@@ -167,6 +172,37 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    extern crate alloc;
+    use alloc::vec;
+
+    fn map_via_inserts<'a>(pairs: &[(&'a str, i32)]) -> VecMap<&'a str, i32> {
+        let mut map = VecMap::new();
+        for &(key, value) in pairs {
+            map.insert(key, value);
+        }
+        map
+    }
+
+    #[test]
+    fn constructor_parity_with_insert() {
+        let input = vec![("a", 1), ("b", 2), ("a", 3)];
+        let expected = map_via_inserts(&[("a", 1), ("b", 2), ("a", 3)]);
+
+        assert_eq!(VecMap::from(input.clone()), expected);
+        assert_eq!(input.into_iter().collect::<VecMap<_, _>>(), expected);
+        assert_eq!(VecMap::from([("a", 1), ("b", 2), ("a", 3)]), expected);
+        assert_eq!(expected.get(&"a"), Some(&3));
+        assert_eq!(expected.as_slice(), &[("a", 3), ("b", 2)]);
+    }
+
+    #[test]
+    fn extend_parity_with_insert() {
+        let mut via_extend = VecMap::new();
+        via_extend.extend([("a", 1), ("b", 2), ("a", 3)]);
+
+        let via_insert = map_via_inserts(&[("a", 1), ("b", 2), ("a", 3)]);
+        assert_eq!(via_extend, via_insert);
+    }
 
     #[test]
     fn eq() {

--- a/src/set.rs
+++ b/src/set.rs
@@ -1067,7 +1067,12 @@ where
     /// assert_eq!(set.len(), 1);
     /// ```
     pub fn insert(&mut self, value: T) -> bool {
-        self.base.insert(value).is_none()
+        if self.contains(&value) {
+            false
+        } else {
+            self.base.push(value);
+            true
+        }
     }
 
     /// Moves all values from `other` into `self`, leaving `other` empty.
@@ -1097,7 +1102,10 @@ where
     /// assert!(a.iter().eq(&[3, 2, 1, 4, 5]));
     /// ```
     pub fn append(&mut self, other: &mut VecSet<T>) {
-        self.base.append(&mut other.base);
+        self.reserve(other.len());
+        for value in other.drain(..) {
+            self.insert(value);
+        }
     }
 }
 

--- a/src/set/impls.rs
+++ b/src/set/impls.rs
@@ -25,7 +25,9 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        self.base.extend(iterable);
+        iterable.into_iter().for_each(|value| {
+            self.insert(value);
+        });
     }
 }
 
@@ -49,9 +51,9 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        VecSet {
-            base: super::KeyedVecSet::from_iter(iter),
-        }
+        let mut set = VecSet::new();
+        set.extend(iter);
+        set
     }
 }
 
@@ -61,12 +63,19 @@ where
 {
     /// Constructs set from a vector.
     ///
+    /// When the input contains equal elements, the first occurrence is kept and
+    /// later equal values are ignored — the same rule as
+    /// [`insert`][VecSet::insert], [`extend`][Extend::extend], and
+    /// [`FromIterator`].
+    ///
     /// **Note**: This conversion has a quadratic complexity because the
     /// conversion preserves order of elements while at the same time having to
     /// make sure no duplicate elements exist. To avoid it, sort and deduplicate
     /// the vector and use [`VecSet::from_vec_unchecked`] instead.
-    fn from(vec: Vec<T>) -> Self {
-        VecSet { base: vec.into() }
+    fn from(mut vec: Vec<T>) -> Self {
+        crate::dedup_keep_first(&mut vec, |lhs, rhs| lhs == rhs);
+        // SAFETY: We've just deduplicated the elements.
+        unsafe { Self::from_vec_unchecked(vec) }
     }
 }
 
@@ -75,7 +84,7 @@ where
     T: Clone + Eq,
 {
     fn from(slice: &[T]) -> Self {
-        VecSet { base: slice.into() }
+        slice.iter().cloned().collect()
     }
 }
 
@@ -84,7 +93,7 @@ where
     T: Clone + Eq,
 {
     fn from(slice: &mut [T]) -> Self {
-        VecSet { base: slice.into() }
+        slice.iter().cloned().collect()
     }
 }
 
@@ -93,7 +102,7 @@ where
     T: Eq,
 {
     fn from(arr: [T; N]) -> Self {
-        VecSet { base: arr.into() }
+        VecSet::from_iter(arr)
     }
 }
 
@@ -163,5 +172,75 @@ where
     /// Values are collected in the same order that they appear in `self`.
     fn sub(self, other: &VecSet<T>) -> Self::Output {
         self.difference(other).cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate alloc;
+    use alloc::vec;
+
+    #[derive(Clone, Debug)]
+    #[allow(dead_code)]
+    struct Item(i32, &'static str);
+
+    impl Eq for Item {}
+
+    impl PartialEq for Item {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    fn set_via_inserts(items: &[Item]) -> VecSet<Item> {
+        let mut set = VecSet::new();
+        for item in items {
+            set.insert(item.clone());
+        }
+        set
+    }
+
+    #[test]
+    fn constructor_parity_with_insert() {
+        let input = vec![Item(1, "first"), Item(2, "b"), Item(1, "second")];
+        let expected = set_via_inserts(&[Item(1, "first"), Item(2, "b"), Item(1, "second")]);
+
+        assert_eq!(VecSet::from(input.clone()), expected);
+        assert_eq!(input.into_iter().collect::<VecSet<_>>(), expected);
+        assert_eq!(
+            VecSet::from([Item(1, "first"), Item(2, "b"), Item(1, "second")]),
+            expected
+        );
+        assert_eq!(expected.as_slice(), &[Item(1, "first"), Item(2, "b")]);
+    }
+
+    #[test]
+    fn insert_rejects_duplicate_without_replacing() {
+        let mut set = VecSet::new();
+        assert!(set.insert(Item(1, "first")));
+        assert!(!set.insert(Item(1, "second")));
+        assert_eq!(set.as_slice(), &[Item(1, "first")]);
+    }
+
+    #[test]
+    fn extend_parity_with_insert() {
+        let mut via_extend = VecSet::new();
+        via_extend.extend([Item(1, "first"), Item(2, "b"), Item(1, "second")]);
+
+        let via_insert = set_via_inserts(&[Item(1, "first"), Item(2, "b"), Item(1, "second")]);
+        assert_eq!(via_extend, via_insert);
+    }
+
+    #[test]
+    fn append_parity_with_insert() {
+        let mut base = set_via_inserts(&[Item(1, "first")]);
+        let mut extra = VecSet::from(vec![Item(1, "second"), Item(2, "b")]);
+
+        base.append(&mut extra);
+
+        let expected = set_via_inserts(&[Item(1, "first"), Item(1, "second"), Item(2, "b")]);
+        assert_eq!(base, expected);
+        assert!(extra.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Align duplicate resolution across all population paths (`From<Vec>`, `collect`, `extend`, `insert`, slice/array) for `VecMap`, `KeyedVecSet`, and `VecSet` (fixes #66).
- Add `dedup_keep_first` and `dedup_keep_last_value` helpers: maps/keyed sets keep the first key position with the last value; sets keep the first equal element and ignore later duplicates.
- Fix `VecSet::insert`, `extend`, and `append`, which previously used map-style replacement instead of set semantics.

Closes #66.